### PR TITLE
Implement Native PDF Text Extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ powershell.log
 
 # Bicep build output (which we don't want)
 infra/main.json
+
+# Script DLL dependencies (which we don't want)
+scripts/lib/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Rename My Files is a PowerShell tool that reads file content and uses Azure Open
 3. Sends minimal context to Azure OpenAI.
 4. Renames each file while keeping its original extension.
 
+
 Example result:
 
 ```
@@ -32,6 +33,7 @@ scan0042.pdf  ->  Acme Ltd Contract Renewal Notice - 13th January 2026.pdf
 - Azure subscription
 - Azure CLI
 - Permission to create resources in the target subscription
+- (Optional) UglyToad.PdfPig NuGet package for PDF text extraction (see below)
 
 ## Quick start
 
@@ -57,6 +59,29 @@ Run for real:
 .\scripts\Rename-MyFiles.ps1 -FolderPath "C:\MyDocuments\Unfiled"
 ```
 
+This command uses built-in low-cost defaults automatically (no AI tuning parameters required).
+
+## Optional: Install PdfPig for PDF text extraction
+
+PDF text extraction requires the PdfPig (.NET library).
+
+To install it:
+
+```powershell
+.\scripts\Install-Dependencies.ps1
+```
+
+This downloads PdfPig from NuGet.org and installs it to a local `lib` folder. **No .NET SDK required** — only PowerShell 7.2+ and an internet connection.
+
+**If PdfPig is not installed:** PDF files will be skipped with a clear warning message explaining how to install it. Run the install script, then run the rename script again.
+
+**To check if PdfPig is available:** Run the rename script with `-Verbose`:
+```powershell
+.\scripts\Rename-MyFiles.ps1 -FolderPath "C:\Documents" -Verbose
+```
+
+If PdfPig is loaded, you will see: `"Successfully loaded PdfPig from: ..."`
+
 ## Parameters (`Rename-MyFiles.ps1`)
 
 | Parameter | Required | Description |
@@ -65,19 +90,25 @@ Run for real:
 | `-AzureOpenAIEndpoint` | No | Azure OpenAI endpoint (or `AZURE_OPENAI_ENDPOINT`) |
 | `-AzureOpenAIKey` | No | Azure OpenAI API key (or `AZURE_OPENAI_KEY`) |
 | `-DeploymentName` | No | Model deployment name (default `gpt-4o-mini`) |
+| `-RequestThrottleSeconds` | No | Delay between API calls (default is conservative for low quota/cost) |
+| `-MaxPromptCharacters` | No | Max content sent per file (default is low-cost) |
 | `-WhatIf` | No | Preview renames without changing files |
 | `-Verbose` | No | Show detailed progress |
 
+
 ## Current behaviour and limits
 
-- Plain text formats are read directly (`.txt`, `.md`, `.csv`, `.log`, `.json`, `.xml`, `.html`, `.htm`, `.yaml`, `.yml`).
-- PDF and Office formats currently use filename context only (no text extraction).
-- Unsupported or unreadable files are skipped.
-- Name collisions are handled with numeric suffixes (`-1`, `-2`, ...).
-- Invalid filename characters and control characters are removed.
-- Repeated whitespace is collapsed.
-- Windows reserved names are made safe by appending `_file`.
-- Overlong filenames are truncated to fit Windows filename limits.
+- **Plain text formats:** Content is read directly (`.txt`, `.md`, `.csv`, `.log`, `.json`, `.xml`, `.html`, `.htm`, `.yaml`, `.yml`).
+- **PDF files:** Text content is extracted and used for naming (requires PdfPig library). If PdfPig is not installed, PDF files are skipped.
+- **Scanned PDFs:** Skipped (image-based, no text to extract).
+- **Password-protected PDFs:** Skipped (decryption not supported).
+- **Office formats:** *Content is not read.* The tool uses only the original filename (e.g. `.docx`, `.xlsx`, `.pptx`). Names may be generic if the filename is not descriptive.
+- **Unsupported or unreadable files:** Skipped automatically.
+- **Name collisions:** Handled with numeric suffixes (`-1`, `-2`, ...).
+- **Invalid filename characters and control characters:** Removed.
+- **Repeated whitespace:** Collapsed.
+- **Windows reserved names:** Made safe by appending `_file`.
+- **Overlong filenames:** Truncated to fit Windows filename limits.
 
 ## Remove resources
 

--- a/README.md
+++ b/README.md
@@ -92,22 +92,21 @@ If PdfPig is loaded, you will see: `"Successfully loaded PdfPig from: ..."`
 | `-DeploymentName` | No | Model deployment name (default `gpt-4o-mini`) |
 | `-RequestThrottleSeconds` | No | Delay between API calls (default is conservative for low quota/cost) |
 | `-MaxPromptCharacters` | No | Max content sent per file (default is low-cost) |
-| `-Force` | No | Force rename even if filename already looks descriptive |
+| `-Force` | No | Instruct AI to suggest a new name even when the current name is already clear |
 | `-WhatIf` | No | Preview renames without changing files |
 | `-Verbose` | No | Show detailed progress |
 
-### Smart Skip (Cost Saving)
+### Existing-name handling
 
-By default, files with already-descriptive names (containing dates and business keywords like "Invoice", "Letter", "Tax Return") are **skipped without calling Azure AI**. This saves cost and quota.
+By default, Azure AI receives the current filename and can decide to keep it unchanged when it is already clear and useful.
 
-To rename all files regardless of their current name quality, use `-Force`:
+If you want AI to always suggest an improved name, use `-Force`:
 
 ```powershell
 .\scripts\Rename-MyFiles.ps1 -FolderPath "C:\Documents" -Force
 ```
 
 Example skip reasons:
-- `already descriptive` — File already has a good name (e.g. `Invoice - 2025-02-15.pdf`)
 - `Filename unchanged` — Azure AI suggested the same name as current
 
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,23 @@ If PdfPig is loaded, you will see: `"Successfully loaded PdfPig from: ..."`
 | `-DeploymentName` | No | Model deployment name (default `gpt-4o-mini`) |
 | `-RequestThrottleSeconds` | No | Delay between API calls (default is conservative for low quota/cost) |
 | `-MaxPromptCharacters` | No | Max content sent per file (default is low-cost) |
+| `-Force` | No | Force rename even if filename already looks descriptive |
 | `-WhatIf` | No | Preview renames without changing files |
 | `-Verbose` | No | Show detailed progress |
+
+### Smart Skip (Cost Saving)
+
+By default, files with already-descriptive names (containing dates and business keywords like "Invoice", "Letter", "Tax Return") are **skipped without calling Azure AI**. This saves cost and quota.
+
+To rename all files regardless of their current name quality, use `-Force`:
+
+```powershell
+.\scripts\Rename-MyFiles.ps1 -FolderPath "C:\Documents" -Force
+```
+
+Example skip reasons:
+- `already descriptive` — File already has a good name (e.g. `Invoice - 2025-02-15.pdf`)
+- `Filename unchanged` — Azure AI suggested the same name as current
 
 
 ## Current behaviour and limits

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,8 +35,8 @@ Your files stay in the same folder — only their names change.
 
 ## Limitations
 
-- Only plain text files (`.txt`, `.md`, `.csv`, etc.) are fully supported out of the box.
-- PDF and Office documents have limited support (the tool currently uses filename context only).
+- Plain text files (`.txt`, `.md`, `.csv`, etc.) and PDF files with PdfPig installed are fully supported.
+- Scanned PDFs, encrypted PDFs, and Office documents have limited/no support and will be skipped.
 - Unsupported or unreadable files are skipped.
 - AI-generated names are suggestions — they may not always be perfect.
 - Only files in the selected folder are processed (subfolders are not scanned).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -146,8 +146,11 @@ Found 8 file(s). Processing...
 | Situation | What happens |
 |-----------|-------------|
 | Image files (`.jpg`, `.png`, etc.) | Skipped — the tool only reads text content |
-| PDF or Office documents | Limited — the tool currently uses filename context only, so names may be generic |
-| Encrypted or password-protected PDF/Office files | Processed using filename context only (text extraction is not implemented) |
+| PDF files with text content (PdfPig installed) | Supported — text is extracted and used for naming |
+| PDF files (PdfPig not installed) | Skipped with a message explaining how to install PdfPig |
+| Scanned PDF files (image-based) | Skipped — no text to extract |
+| Password-protected or encrypted PDF files | Skipped — decryption not supported |
+| Office documents (`.docx`, `.xlsx`, `.pptx`, etc.) | Limited — the tool currently uses filename context only, so names may be generic |
 | Corrupted or unreadable plain-text files | Skipped — the file cannot be read |
 | Very short or empty files | The AI may produce a generic or imperfect name |
 | File with the same proposed name already exists | A numeric suffix is added (e.g. `-1`, `-2`) |
@@ -155,11 +158,41 @@ Found 8 file(s). Processing...
 | Proposed filename contains control characters, tabs, or newlines | These characters are removed entirely |
 | Proposed filename matches a Windows reserved device name (e.g. CON, PRN, NUL, COM1) | Name is made safe by appending _file |
 | Excess spaces | Multiple spaces are collapsed to a single space |
+| Azure API rate limit exceeded | File is skipped. Script retries automatically and already uses low-cost defaults (conservative pacing + reduced prompt size). If this still happens, wait a few minutes and try again, or increase Azure OpenAI quota. |
 
 - **AI names are suggestions.** The AI does its best but may occasionally produce imperfect names. Review the dry-run output before renaming important files.
 - **Only the filename changes.** The tool never modifies the content of any file.
 - **Only files in the top-level folder are processed.** Sub-folders are not scanned.
 - **The summary reports renamed and skipped files.** Any file-level failure is recorded as skipped with a reason.
+
+### Enabling PDF text extraction
+
+PDF text extraction requires the PdfPig library. To enable it:
+
+1. Open a PowerShell 7 terminal.
+2. Navigate to the folder where you have the Rename My Files scripts.
+3. Run the installation script:
+   ```powershell
+   .\scripts\Install-Dependencies.ps1
+   ```
+4. The script will download PdfPig from NuGet.org and install it automatically.
+5. Run the rename script:
+   ```powershell
+   .\scripts\Rename-MyFiles.ps1 -FolderPath "C:\Documents\MyFolder"
+   ```
+
+**What happens if PdfPig is not installed?**
+- PDF files are skipped with a clear `⚠️ WARNING` message at the start of the script.
+- The message tells you exactly how to install it (run `Install-Dependencies.ps1`).
+- Once you install PdfPig, run the rename script again — no configuration needed.
+
+**Verify PdfPig is loaded:** Run the rename script with `-Verbose`:
+```powershell
+.\scripts\Rename-MyFiles.ps1 -FolderPath "C:\Documents\MyFolder" -Verbose
+```
+Look for: `"Successfully loaded PdfPig from: ..."` in the output.
+
+**Requirements:** PowerShell 7.2+ and an internet connection. No .NET SDK required.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -105,28 +105,27 @@ This will show you proposed renames **without actually changing anything**. Revi
 
 ---
 
-## Smart Skip (Saving Cost and Quota)
+## Existing-name handling
 
-The tool automatically **skips files that already have good names** to save cost and quota. Files with dates and business keywords (like "Invoice", "Contract", "Tax Return") are considered already descriptive and are skipped without calling Azure AI.
+The tool sends the current filename and document content to Azure AI. If the current filename is already clear and useful, Azure AI can return it unchanged.
 
 ### Example Skip Reasons
 
 | File | Reason | Called AI? |
 |------|--------|-----------|
-| `Invoice - 2025-02-15.pdf` | Already descriptive | ❌ No |
-| `scan0042.pdf` | No, needs AI | ✅ Yes |
-| `Dr Smith Letter - 15 Feb 2025.txt` | Already descriptive | ❌ No |
-| `Document (3).docx` | No, needs AI | ✅ Yes |
+| `Invoice - 2025-02-15.pdf` | Filename unchanged | ✅ Yes |
+| `scan0042.pdf` | Renamed | ✅ Yes |
+| `Document (3).docx` | Renamed | ✅ Yes |
 
 ### Force Rename Everything
 
-If you want to rename **all** files regardless of their current names, use `-Force`:
+If you want Azure AI to always suggest a new name, use `-Force`:
 
 ```powershell
 .\scripts\Rename-MyFiles.ps1 -FolderPath "C:\Documents\MyUnfiledFolder" -Force
 ```
 
-This tells the tool to process every file, even if it already looks descriptive. Useful if you want consistent naming across your entire collection.
+This tells the tool to ask Azure AI for an improved name even when the current filename already looks good. Useful if you want stricter naming consistency across your collection.
 
 ---
 
@@ -139,8 +138,7 @@ Once you are happy with the preview:
 ```
 
 The script will:
-- Check which files already have good names (skip them to save cost).
-- Read each file that might need renaming.
+- Read each supported file.
 - Ask Azure AI to suggest a descriptive name.
 - Rename the file, keeping the same extension.
 - Show a summary at the end.
@@ -151,7 +149,7 @@ Example output:
 Scanning folder: C:\Documents\MyUnfiledFolder
 Found 8 file(s). Processing...
 
-   SKIPPED  Invoice - 2025-02-15.pdf -- already descriptive
+   SKIPPED  Invoice - 2025-02-15.pdf -- filename unchanged
    RENAMED  scan0042.pdf  ->  Acme Ltd Invoice - January 2025.pdf
    RENAMED  Document (3).docx  ->  HMRC Self Assessment Tax Return 2024-25.docx
    SKIPPED  photo.jpg -- Unsupported or unreadable file type
@@ -165,8 +163,7 @@ Found 8 file(s). Processing...
  Files skipped    : 5
 
  Skip breakdown:
-   - Already descriptive : 1
-   - Unsupported         : 1
+   - Filename unchanged   : 1
 -------------------------------------
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -105,6 +105,31 @@ This will show you proposed renames **without actually changing anything**. Revi
 
 ---
 
+## Smart Skip (Saving Cost and Quota)
+
+The tool automatically **skips files that already have good names** to save cost and quota. Files with dates and business keywords (like "Invoice", "Contract", "Tax Return") are considered already descriptive and are skipped without calling Azure AI.
+
+### Example Skip Reasons
+
+| File | Reason | Called AI? |
+|------|--------|-----------|
+| `Invoice - 2025-02-15.pdf` | Already descriptive | ❌ No |
+| `scan0042.pdf` | No, needs AI | ✅ Yes |
+| `Dr Smith Letter - 15 Feb 2025.txt` | Already descriptive | ❌ No |
+| `Document (3).docx` | No, needs AI | ✅ Yes |
+
+### Force Rename Everything
+
+If you want to rename **all** files regardless of their current names, use `-Force`:
+
+```powershell
+.\scripts\Rename-MyFiles.ps1 -FolderPath "C:\Documents\MyUnfiledFolder" -Force
+```
+
+This tells the tool to process every file, even if it already looks descriptive. Useful if you want consistent naming across your entire collection.
+
+---
+
 ## Step 4 — Rename Your Files
 
 Once you are happy with the preview:
@@ -114,7 +139,8 @@ Once you are happy with the preview:
 ```
 
 The script will:
-- Read each file in the folder.
+- Check which files already have good names (skip them to save cost).
+- Read each file that might need renaming.
 - Ask Azure AI to suggest a descriptive name.
 - Rename the file, keeping the same extension.
 - Show a summary at the end.
@@ -125,7 +151,8 @@ Example output:
 Scanning folder: C:\Documents\MyUnfiledFolder
 Found 8 file(s). Processing...
 
-   RENAMED  scan0042.pdf  ->  Acme Ltd Invoice - February 2025.pdf
+   SKIPPED  Invoice - 2025-02-15.pdf -- already descriptive
+   RENAMED  scan0042.pdf  ->  Acme Ltd Invoice - January 2025.pdf
    RENAMED  Document (3).docx  ->  HMRC Self Assessment Tax Return 2024-25.docx
    SKIPPED  photo.jpg -- Unsupported or unreadable file type
    RENAMED  letter.txt  ->  Dr Smith Referral Letter - John Doe.txt
@@ -133,9 +160,13 @@ Found 8 file(s). Processing...
 -------------------------------------
  Summary
 -------------------------------------
- Files scanned : 8
- Files renamed : 3
- Files skipped : 1
+ Files scanned    : 8
+ Files renamed    : 3
+ Files skipped    : 5
+
+ Skip breakdown:
+   - Already descriptive : 1
+   - Unsupported         : 1
 -------------------------------------
 ```
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -9,8 +9,8 @@
 //     GlobalStandard provides good performance and global routing at competitive cost.
 //   - GPT-4o mini: cheapest capable model for understanding document content and generating
 //     descriptive filenames.
-//   - Capacity: 1 (minimum) = 1,000 tokens-per-minute for interactive single-file processing.
-//     TODO: Increase capacity if batch-processing large folders is needed.
+//   - Capacity: 10 = 10,000 tokens-per-minute for smoother interactive and small-batch processing.
+//     This improves usability while remaining pay-per-token for cost control.
 
 @description('Azure region for all resources.')
 param location string = resourceGroup().location
@@ -20,6 +20,9 @@ param resourceNamePrefix string = 'rmf'
 
 @description('Name of the Azure OpenAI model deployment.')
 param modelDeploymentName string = 'gpt-4o-mini'
+
+@description('Set to true only when restoring a soft-deleted Azure OpenAI resource.')
+param restoreOpenAI bool = false
 
 // ---------------------------------------------------------------------------
 // Variables
@@ -49,7 +52,7 @@ resource openAIAccount 'Microsoft.CognitiveServices/accounts@2023-10-01-preview'
   properties: {
     customSubDomainName: openAIResourceName
     publicNetworkAccess: 'Enabled'
-    restore: true
+    restore: restoreOpenAI
     // TODO: For a production or sensitive workload, consider restricting to a
     // private endpoint and disabling public network access.
   }
@@ -61,17 +64,17 @@ resource openAIAccount 'Microsoft.CognitiveServices/accounts@2023-10-01-preview'
 //
 // Model: gpt-4o-mini — cheapest capable GPT-4-class model as of 2025.
 // Deployment type: GlobalStandard — available in uksouth and other regions.
-// Capacity: 1 (minimum) = 1,000 tokens-per-minute.
+// Capacity: 10 = 10,000 tokens-per-minute.
 //   - For a typical document of ~500 words (~700 tokens input + ~60 tokens output),
-//     this allows roughly 1 rename per minute. Sufficient for interactive use.
-//   - TODO: Increase capacity (e.g. to 10 or 30) if processing large batches.
+//     this supports smoother interactive use and small-batch runs.
+//   - For larger batches, consider higher capacity if needed.
 
 resource modelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-09-01' = {
   parent: openAIAccount
   name: modelDeploymentName
   sku: {
     name: 'GlobalStandard'
-    capacity: 1
+    capacity: 10
   }
   properties: {
     model: {

--- a/plan/DECISIONS/ADR-0003-globalstandard-deployment-type.md
+++ b/plan/DECISIONS/ADR-0003-globalstandard-deployment-type.md
@@ -152,13 +152,13 @@ resource cognitiveServicesDeployment 'Microsoft.CognitiveServices/accounts/deplo
     }
     scaleSettings: {
       scaleType: 'Standard'
-      capacity: 1
+      capacity: 10
     }
     versionUpgradeOption: 'OnceCurrentVersionExpired'
   }
   sku: {
     name: 'GlobalStandard'  // ← This is the critical setting
-    capacity: 1
+    capacity: 10
   }
 }
 ```

--- a/plan/DECISIONS/ADR-0005-pdf-text-extraction.md
+++ b/plan/DECISIONS/ADR-0005-pdf-text-extraction.md
@@ -1,0 +1,199 @@
+# ADR-0005: PDF Text Extraction Method Selection
+
+## Status
+
+Accepted
+
+## Context
+
+Phase 6a requires replacing the placeholder PDF extraction logic (currently returns `[PDF file: <filename>]`) with real text extraction. This decision evaluates multiple approaches based on the project's constraints:
+
+- **Cross-platform requirement:** Windows, macOS, Linux must all work identically.
+- **Installation complexity:** Prefer NuGet packages over external CLI utilities (easier distribution, no PATH dependency).
+- **Licensing:** No proprietary, closed-source, or expensive licenses.
+- **Error resilience:** Malformed, encrypted, or corrupted PDFs must fall back gracefully without stopping the batch.
+- **Dependencies:** Minimal impact on script footprint; no heavy runtime requirements.
+- **Integration:** PowerShell 7 native (can use .NET libraries via `Add-Type` or import via assembly).
+
+## Evaluation of Candidates
+
+### 1. PdfPig
+
+**Library:** `UglyToad.PdfPig` (NuGet package)
+
+**Size:** ~500 KB (core + dependencies)
+
+**Licensing:** MIT (fully open source, permissive)
+
+**Cross-Platform:** Yes (works with .NET Core / .NET 5+)
+
+**Installation:** NuGet package; load in PowerShell via `Add-Type -Path`
+
+**Error Handling:**
+- Designed to handle malformed PDFs gracefully (doesn't throw on corrupted headers).
+- Returns empty or partial text from corrupted documents.
+- Does not decrypt password-protected PDFs; returns empty string.
+
+**Pros:**
+- Lightweight and minimal dependencies.
+- MIT license explicitly permits commercial use.
+- Actively maintained (last update: 2024).
+- Works cross-platform without external utilities.
+- Handles edge cases (corrupted, truncated, scanned PDFs) without crashing.
+- Can be redistributed with the script as a NuGet assembly.
+
+**Cons:**
+- Requires .NET runtime availability (PowerShell 7 provides this).
+- No built-in support for scanning (image-based) PDFs.
+- May extract limited text from complex layouts (acceptable; better than filename context).
+
+**Recommendation:** ✅ **RECOMMENDED**
+
+---
+
+### 2. pdftotext (Poppler utility)
+
+**Tool:** External command-line utility (part of Poppler PDF rendering library)
+
+**Licensing:** GPL / Apache 2.0 (open source)
+
+**Cross-Platform:** Yes (available for Windows, macOS, Linux)
+
+**Installation:** System-level installation required (not bundled with PowerShell)
+
+**Error Handling:**
+- Returns exit code 1 on encrypted/corrupted PDFs; falls back easily.
+- Supports per-page extraction.
+
+**Pros:**
+- Battle-tested, widely used.
+- Good text extraction quality.
+- Can extract from encrypted PDFs with optional password.
+
+**Cons:**
+- ❌ Requires separate installation on each machine (breaks "minimal setup" goal).
+- ❌ PATH dependency; easy to break if utility moves or is not in PATH.
+- ❌ Not bundled with PowerShell; distribution burden.
+- ❌ External process overhead per PDF (slower than library).
+- Different versions on Windows, macOS, Linux → testing burden.
+
+**Recommendation:** ❌ **NOT RECOMMENDED** (installation friction too high for user base)
+
+---
+
+### 3. iTextSharp
+
+**Library:** `iTextSharp` (NuGet package)
+
+**Licensing:** AGPL v3 (open source) for versions < 5.1; later versions proprietary (requires commercial license for redistribution)
+
+**Cross-Platform:** Yes (.NET library)
+
+**Installation:** NuGet package
+
+**Error Handling:** Robust error handling, but licensing complexity makes it risky for commercial use.
+
+**Pros:**
+- Very mature, feature-rich.
+- Handles complex PDFs well.
+
+**Cons:**
+- ❌ **Licensing conflict:** iTextSharp ≥ 5.0 is AGPL; redistribution requires open-sourcing or commercial license.
+- ❌ Licensing model creates legal risk if the tool is distributed to users without explicit compliance.
+- Overkill for simple text extraction (heavier than needed).
+- Community is fragmenting due to license issues.
+
+**Recommendation:** ❌ **NOT RECOMMENDED** (licensing risk outweighs features)
+
+---
+
+### 4. Azure Document Intelligence (formerly Form Recognizer)
+
+**Service:** Cloud-based AI service (Microsoft Azure)
+
+**Licensing:** Per-page usage fee (~$1–$2 per page depending on tier)
+
+**Cross-Platform:** Yes (cloud service, language-agnostic)
+
+**Installation:** No local installation; calls Azure REST API
+
+**Error Handling:** Returns structured data or error; handles encrypted PDFs gracefully.
+
+**Pros:**
+- Excellent OCR for scanned documents.
+- Handles complex layouts, handwriting, tables.
+- Cloud-based; no local dependency.
+
+**Cons:**
+- ❌ **Cost:** Adds per-page cost to every file rename. For a 100-page PDF, cost is $2. For a user batch-renaming 50 PDFs (avg 10 pages each) = ~$10 per batch. Unacceptable overhead.
+- ❌ Adds new Azure service dependency (resource, quota management, cost tracking).
+- ❌ Cloud API latency (slower than local extraction).
+- ❌ Privacy concern: PDF pages must be sent to Azure cloud (not suitable for sensitive documents).
+- Out of scope per project decisions (single AI backend for naming, not extracting).
+
+**Recommendation:** ❌ **NOT RECOMMENDED** (cost and privacy concerns)
+
+---
+
+## Decision
+
+**Selected Method: PdfPig (UglyToad.PdfPig)**
+
+We will replace the PDF placeholder extraction in `Rename-MyFiles.ps1` with PdfPig-based extraction.
+
+### Rationale
+
+- **MIT License:** Fully permissive; no commercial redistribution concerns.
+- **No external dependency:** Works entirely within PowerShell/.NET; no PATH setup required.
+- **Cross-platform:** Compatible with Windows, macOS, Linux via PowerShell 7.
+- **Minimal footprint:** ~500 KB core; easily bundled with the script or installed via NuGet.
+- **Error resilience:** Corrupted, encrypted, or malformed PDFs do not throw; extract what is readable or return empty gracefully.
+- **Integration:** Load via `Add-Type` in PowerShell; familiar pattern.
+- **Active maintenance:** Library is under active development (as of 2024).
+
+### Implementation Plan
+
+1. **Dependency management:**
+   - Add `UglyToad.PdfPig` as a NuGet reference in the script or a supporting manifest.
+   - Document installation: `Install-Package UglyToad.PdfPig` (requires NuGet or manual assembly bundle).
+   - Consider shipping pre-compiled assembly as an optional bundle in `/lib` folder to avoid runtime NuGet calls.
+
+2. **Code changes:**
+   - Replace placeholder in `Get-FileTextContent` (lines 92–100 of `Rename-MyFiles.ps1`).
+   - Load PdfPig assembly at script startup.
+   - Extract text up to 8000 characters (existing limit).
+   - Catch and fall back to placeholder on read failure (malformed, encrypted, etc.).
+
+3. **Testing:**
+   - Small text-based PDF (normal case).
+   - Scanned/image-based PDF (expect empty or limited text; fallback acceptable).
+   - Encrypted PDF (expect empty; fallback acceptable).
+   - Corrupted PDF (expect graceful failure; fallback acceptable).
+   - Windows, macOS, Linux (if cross-platform testing available).
+
+4. **Documentation:**
+   - Update README.md and user-guide.md: PDF support added (with caveats for scanned/encrypted).
+   - Update RUNBOOK.md: PDF text extraction now enabled.
+   - Note: Scanned PDFs still rely on filename context (no OCR in MVP).
+
+### Future Considerations
+
+- If image-based PDFs (scanned documents) must be OCR'd, defer to Phase 7 (Image Support Feasibility).
+- If Azure Document Intelligence is later approved for vision/OCR tasks, it would be a separate decision with explicit cost and privacy trade-offs documented.
+
+## Consequences
+
+**Positive:**
+- Users can rename PDFs with real content extraction (substantial quality improvement over placeholder).
+- No new external dependencies or PATH setup required.
+- MIT license eliminates legal/regulatory risk.
+- Graceful fallback for edge cases (corrupted, encrypted, unusual PDFs).
+
+**Negative:**
+- Adds a .NET library dependency (PdfPig assembly must be available at runtime).
+- Scanned PDFs will still return empty or minimal text (acceptable; OCR is out of scope).
+- Encrypted PDFs cannot be read without password (acceptable; password handling is out of scope).
+
+**Neutral:**
+- Slight increase in script complexity (assembly loading, error handling for PDF parsing).
+- ~500 KB download/storage overhead if bundled.

--- a/plan/DECISIONS/ADR-0005-rate-limiting-strategy.md
+++ b/plan/DECISIONS/ADR-0005-rate-limiting-strategy.md
@@ -32,7 +32,8 @@ Azure OpenAI enforces two main limits:
 - Manual quota checks: Rejected in favour of automatic handling and clear documentation.
 
 ## References
-- Azure OpenAI documentation on rate limits and quotas
+- [Azure OpenAI rate limits and quotas](https://learn.microsoft.com/en-us/azure/ai-services/openai/quotas-limits)
+- [Azure OpenAI REST API reference](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)
 - Implementation in `scripts/Rename-MyFiles.ps1` (see error handling and throttle logic)
 
 ---

--- a/plan/DECISIONS/ADR-0005-rate-limiting-strategy.md
+++ b/plan/DECISIONS/ADR-0005-rate-limiting-strategy.md
@@ -1,0 +1,40 @@
+# ADR-0005: Rate Limiting Strategy for Azure OpenAI
+
+## Status
+Accepted
+
+## Context
+
+The Rename My Files project uses Azure OpenAI to generate descriptive filenames based on file content. Early in development, the deployment was provisioned with a low quota (1K TPM), which led to frequent rate limiting and slow throughput. This affected both user experience and the perceived effectiveness of our rate limiting logic.
+
+Azure OpenAI enforces two main limits:
+- **Quota**: The maximum number of tokens per minute (TPM) and requests per minute (RPM) allowed by the deployment.
+- **Rate Limiting**: When requests exceed quota, the API returns HTTP 429 with a `Retry-After` header indicating when to retry.
+
+## Decision
+
+- **Default Throttle**: The script now defaults to a 5-second delay (`RequestThrottleSeconds`) between requests, balancing throughput and cost for typical quotas (10K TPM or higher).
+- **Prompt Size**: The default prompt size is set to 900 characters (`MaxPromptCharacters`), optimised for cost and compliance with quota.
+- **Automatic Handling**: The script automatically parses `Retry-After` headers and applies exponential backoff if rate limited, ensuring robust operation even if quota is temporarily exceeded.
+- **User Experience**: For non-technical users, defaults are tuned for low cost and reliability. Advanced users can override throttle and prompt size via parameters.
+- **Quota Awareness**: Documentation and deployment guidance now emphasise the importance of setting an appropriate quota in Azure (minimum 10K TPM recommended for reasonable throughput).
+
+## Consequences
+
+- The script is resilient to rate limiting and quota changes, with clear user-facing defaults.
+- Throughput is now appropriate for typical quotas, and users can adjust parameters if needed.
+- Early results were affected by low quota, but the final strategy is robust for higher quotas and scales with deployment.
+
+## Alternatives Considered
+
+- Aggressive retry/backoff: Rejected due to cost and risk of hitting hard limits.
+- Static long delays (30s+): Rejected as unnecessarily slow for higher quotas.
+- Manual quota checks: Rejected in favour of automatic handling and clear documentation.
+
+## References
+- Azure OpenAI documentation on rate limits and quotas
+- Implementation in `scripts/Rename-MyFiles.ps1` (see error handling and throttle logic)
+
+---
+
+*This ADR documents the rationale and final strategy for rate limiting in Rename My Files, ensuring robust, user-friendly operation regardless of quota.*

--- a/plan/DECISIONS/ADR-0006-rate-limiting-strategy.md
+++ b/plan/DECISIONS/ADR-0006-rate-limiting-strategy.md
@@ -1,4 +1,4 @@
-# ADR-0005: Rate Limiting Strategy for Azure OpenAI
+# ADR-0006: Rate Limiting Strategy for Azure OpenAI
 
 ## Status
 Accepted

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -30,7 +30,7 @@ This plan breaks work into small, testable tasks. Update it when the code change
   - Uses Azure CLI (`az`) for safe resource group deletion.
   - Prompts for confirmation; supports `–Force` flag.
 - All documentation (README, user guide, runbook) updated to reflect current behaviour and limitations.
-- Architecture decisions documented in `DECISIONS/` (ADR-0001 through ADR-0005).
+- Architecture decisions documented in `DECISIONS/` (ADR-0001 through ADR-0006).
 
 ### Known Limitations (Current Implementation)
 
@@ -228,12 +228,12 @@ This plan breaks work into small, testable tasks. Update it when the code change
   - [x] Added PdfPig assembly loading at script startup (lines 78–113).
   - [x] Extract up to 8000 characters (existing limit maintained).
   - [x] Handle unsupported/encrypted/malformed PDFs by catching errors and falling back gracefully.
-  - [x] Return extracted text or placeholder, never throw.
+  - [x] Return extracted text or $null on failure; never throws (dependency errors logged as warnings, file is skipped).
 - [x] Critical fixes after initial implementation:
   - [x] **Removed fallback to filename context** (lines 188–203): PDFs now skipped (not degraded) if PdfPig unavailable.
   - [x] **Added RateLimitReached detection and exponential backoff** (lines 227–348): Detects HTTP 429 or "RateLimitReached" errors. Retries up to 3 times with exponential backoff. Provides explicit warning.
   - [x] **Improved rate limit handling with Retry-After headers** (lines 304–365): Reads `Retry-After` or `retry-after-ms` headers from Azure OpenAI responses (Microsoft recommended approach). Adds jitter (±25% random variation) to avoid thundering herd. Falls back to exponential backoff if headers unavailable. Better error messages distinguishing TPM vs RPM limits.
-  - [x] **Added request throttling/pacing** (new parameter `RequestThrottleSeconds`, default 1s): Adds configurable delay between API calls to avoid bursting into Token-Per-Minute (TPM) limits. Prevents "first call succeeds, all others fail" pattern common with TPM quotas.
+  - [x] **Added request throttling/pacing** (new parameter `RequestThrottleSeconds`, default 5s): Adds configurable delay between API calls to avoid bursting into Token-Per-Minute (TPM) limits. Prevents "first call succeeds, all others fail" pattern common with TPM quotas.
   - [x] **Added explicit PdfPig missing warning** (lines 104–111): Script warns users at startup if PdfPig not loaded.
   - [x] **Created Install-Dependencies.ps1 script**: Automates PdfPig installation. Fixed package name (PdfPig vs UglyToad.PdfPig), API version (v2 vs v3), and version (0.1.13).
   - [x] **Fixed Install-Dependencies.ps1 to install all transitive dependencies**: Now copies all 7 DLLs from NuGet package (not just main assembly). Fixed Split-Path parameter compatibility. Added file-locking error handling.

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -201,35 +201,56 @@ This plan breaks work into small, testable tasks. Update it when the code change
 **Priority:** High (most common document type after plain text)
 
 #### Task: Research & Select PDF Extraction Method
-- [ ] Investigate PDF extraction options:
+- [x] Investigate PDF extraction options:
   - **PdfPig** (.NET library, approx. 500 KB, MIT licensed, cross-platform via .NET Core/Framework).
   - **pdftotext** (external utility, requires installation and PATH setup).
   - **iTextSharp** (.NET library, commercial license considerations).
   - **Azure Document Intelligence** (cloud service, costs per page, adds dependency).
-- [ ] Evaluation criteria:
+- [x] Evaluation criteria:
   - Cross-platform support (Windows, macOS, Linux).
   - Cross-platform installation ease (NuGet package preferred over external utilities).
   - Licensing (no proprietary/expensive licenses).
   - Error handling (malformed/encrypted PDFs fall back gracefully).
   - Size (minimal impact on script distribution).
-- [ ] Document recommendation and rationale in [DECISIONS/ADR-000X-pdf-extraction.md](DECISIONS/) (future ADR).
+- [x] Document recommendation and rationale in [DECISIONS/ADR-0005-pdf-text-extraction.md](DECISIONS/ADR-0005-pdf-text-extraction.md).
+  - **Recommended Method:** PdfPig (UglyToad.PdfPig)
+  - **Rationale:** MIT license, no external dependencies, cross-platform, robust error handling, minimal footprint.
+  - **Not Recommended:** pdftotext (installation friction), iTextSharp (licensing risk), Azure Document Intelligence (cost + privacy concerns).
 
 #### Task: Implement PDF Text Extraction
-- [ ] Modify `Get-FileTextContent` function in [scripts/Rename-MyFiles.ps1](scripts/Rename-MyFiles.ps1) (lines 93–101).
-  - Replace placeholder logic returning `[PDF file: <filename>]` with real extraction.
-  - Extract up to 8000 characters (existing limit).
-  - Handle unsupported/encrypted/malformed PDFs by catching errors and falling back to filename context.
-  - Return extracted text or placeholder, never throw.
-- [ ] Add new prerequisite documentation (if library requires installation).
-  - Specify exact NuGet package version or external utility version.
-  - Document installation steps for Windows, macOS, and Linux.
-- [ ] Test with realistic PDF samples:
-  - Text-based PDF (e.g., Office document exported to PDF).
-  - Scanned PDF (image-based, text extraction may fail — fallback to context).
-  - Encrypted/password-protected PDF (decryption not required; fallback to context).
-  - Malformed/corrupted PDF (invalid header; fallback to context).
-- [ ] Update user-guide.md to list PDF extraction under supported file types.
-  - Note any limitations (e.g., scanned PDFs, encrypted PDFs use context).
+- [x] Modify `Get-FileTextContent` function in [scripts/Rename-MyFiles.ps1](scripts/Rename-MyFiles.ps1).
+  - [x] Replaced placeholder logic with real PDF text extraction using PdfPig.
+  - [x] Implemented `Get-PdfTextContent` helper function (lines 110–168).
+  - [x] Added PdfPig assembly loading at script startup (lines 78–113).
+  - [x] Extract up to 8000 characters (existing limit maintained).
+  - [x] Handle unsupported/encrypted/malformed PDFs by catching errors and falling back gracefully.
+  - [x] Return extracted text or placeholder, never throw.
+- [x] Critical fixes after initial implementation:
+  - [x] **Removed fallback to filename context** (lines 188–203): PDFs now skipped (not degraded) if PdfPig unavailable.
+  - [x] **Added RateLimitReached detection and exponential backoff** (lines 227–348): Detects HTTP 429 or "RateLimitReached" errors. Retries up to 3 times with exponential backoff. Provides explicit warning.
+  - [x] **Improved rate limit handling with Retry-After headers** (lines 304–365): Reads `Retry-After` or `retry-after-ms` headers from Azure OpenAI responses (Microsoft recommended approach). Adds jitter (±25% random variation) to avoid thundering herd. Falls back to exponential backoff if headers unavailable. Better error messages distinguishing TPM vs RPM limits.
+  - [x] **Added request throttling/pacing** (new parameter `RequestThrottleSeconds`, default 1s): Adds configurable delay between API calls to avoid bursting into Token-Per-Minute (TPM) limits. Prevents "first call succeeds, all others fail" pattern common with TPM quotas.
+  - [x] **Added explicit PdfPig missing warning** (lines 104–111): Script warns users at startup if PdfPig not loaded.
+  - [x] **Created Install-Dependencies.ps1 script**: Automates PdfPig installation. Fixed package name (PdfPig vs UglyToad.PdfPig), API version (v2 vs v3), and version (0.1.13).
+  - [x] **Fixed Install-Dependencies.ps1 to install all transitive dependencies**: Now copies all 7 DLLs from NuGet package (not just main assembly). Fixed Split-Path parameter compatibility. Added file-locking error handling.
+  - [x] **Fixed PdfPig API usage**: Changed from `.Pages` property to `.GetPages()` method (correct API for v0.1.13).
+  - [x] **Fixed error reporting**: Dependency loading errors now throw with installation instructions instead of silently failing as "corrupted PDF".
+- [x] Add new prerequisite documentation.
+  - [x] Updated README.md with PdfPig optional dependency (UglyToad.PdfPig).
+  - [x] Added "Optional: Install PdfPig for PDF text extraction" section to README.md with clear consequences.
+  - [x] Updated prerequisites list with optional PdfPig package.
+- [x] Test with realistic PDF samples (manual validation).
+  - [x] Text-based PDF: extraction works; returns null on parsing errors.
+  - [x] Scanned PDF: returns null; file skipped (not degraded to filename).
+  - [x] Encrypted/password-protected PDF: parsing error caught; file skipped.
+  - [x] Malformed/corrupted PDF: parsing error caught; file skipped.
+  - [x] RateLimitReached error: detected, retried with backoff, explicitly reported if persistent.
+  - [x] Error handling ensures no file halts batch processing.
+- [x] Update user-guide.md and index.md to reflect PDF extraction support with caveats.
+  - [x] Updated "Limitations and Caveats" table in user-guide.md (clearer rows for PDF states).
+  - [x] Added Azure API rate limit row to limitations table with guidance.
+  - [x] Updated "Enabling PDF text extraction" section with PdfPig installation and consequence documentation.
+  - [x] Updated docs/index.md limitations section to accurately reflect PDF text support.
 
 ### Phase 6b - Office Document Text Extraction
 

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -252,6 +252,105 @@ This plan breaks work into small, testable tasks. Update it when the code change
   - [x] Updated "Enabling PDF text extraction" section with PdfPig installation and consequence documentation.
   - [x] Updated docs/index.md limitations section to accurately reflect PDF text support.
 
+### Phase 6-Smart-Skip: Intelligent Skip Logic for Already-Descriptive Filenames
+
+**Status:** ✅ **Complete**
+
+**Priority:** High (improves UX by avoiding unnecessary/redundant renames)
+
+**Objective:** Skip files that already have descriptive names or would result in no filename change, allowing users to focus AI processing on files that need renaming.
+
+**Rationale:** Some files already have good names (e.g. `Acme Ltd Invoice - 2025-02-15.pdf`). Processing these through Azure AI is wasteful (cost + energy + quota). Users can optionally force renaming with `-Force` if needed.
+
+#### Task: Add Smart Skip Logic
+- [x] Implement `Test-FilenameIsDescriptive` helper function to detect if current filename looks "already good".
+  - [x] Check for date patterns: YYYY-MM-DD, "Month Year", "Month YYYY", YYYY, MM/DD/YYYY, DD/MM/YYYY.
+  - [x] Check for business keywords: Invoice, Receipt, Statement, Letter, Report, Agreement, Contract, Proposal, Quote, Order, Payment, Tax, Return, Refund, etc.
+  - [x] Return `$true` if filename contains both a date pattern AND at least one business keyword.
+  - [x] Return `$false` for generic filenames like `Document.docx`, `scan0042.pdf`, `File (3).txt`.
+  - Code location: [scripts/Rename-MyFiles.ps1](scripts/Rename-MyFiles.ps1#L552-L598)
+- [x] Add `-Force` parameter to `Rename-MyFiles.ps1`.
+  - [x] Allow forcing rename of already-descriptive files (bypass smart skip logic).
+  - [x] Update help text: "Force rename even if current filename appears already descriptive."
+  - Code location: [scripts/Rename-MyFiles.ps1](scripts/Rename-MyFiles.ps1#L50-L52) and parameter block lines 91–93.
+- [x] Modify main processing loop to check both conditions before renaming:
+  - [x] If current filename is descriptive AND `-Force` not set: Skip before calling Azure AI (saves cost).
+  - [x] If new filename == current filename (case-insensitive): Skip with reason "Filename unchanged".
+  - [x] Otherwise: Proceed to rename.
+  - Code location: [scripts/Rename-MyFiles.ps1](scripts/Rename-MyFiles.ps1#L620-L640) and [lines 667–675](scripts/Rename-MyFiles.ps1#L667-L675).
+- [x] Update summary reporting.
+  - [x] Count files skipped due to "already descriptive" separately.
+  - [x] Count files skipped due to "unchanged" separately.
+  - [x] Display both counts in summary output.
+  - Code location: [scripts/Rename-MyFiles.ps1](scripts/Rename-MyFiles.ps1#L723-L736)
+- [x] Update dry-run (`-WhatIf`) behavior.
+  - [x] Show "SKIPPED (already descriptive)" for files with good names.
+  - [x] Show "SKIPPED (filename unchanged)" for identical filenames.
+  - [x] Show "PROPOSED" for files that would be renamed.
+
+#### Task: Test Smart Skip Logic
+- [x] Test with realistic file samples:
+  - [x] File with date + business keyword already present (e.g. `Invoice - 2025-02-15.pdf`): should skip without -Force.
+  - [x] File with `-Force` flag and good name: should rename anyway.
+  - [x] File with unchanged proposal (e.g. AI suggests same name): should skip.
+  - [x] Generic filename (`Document.docx`, `scan0042.pdf`): should always attempt rename.
+  - [x] Mixed batch (some good, some generic): verify skip counts correct in summary.
+- [x] Validate dry-run output shows correct skip reasons.
+
+#### Acceptance Criteria
+- [x] Script runs without errors (PSScriptAnalyzer passes).
+- [x] `-Force` parameter is present and functional in script help.
+- [x] Files with descriptive names (date + business keyword) are skipped by default.
+- [x] Files with no keywords (generic names) are always processed.
+- [x] Files with `RequestThrottleSeconds` and `-Force` allow forcing re-process.
+- [x] Summary shows breakdown of skip reasons (already descriptive, unchanged, etc).
+- [x] Dry-run correctly shows "SKIPPED" vs "PROPOSED" based on smart logic.
+
+#### Validation Steps
+1. **Dry-run with mixed filenames:**
+   ```powershell
+   $testDir = 'C:\temp\test-files'
+   
+   # Create test files
+   @{
+       'Invoice - 2025-02-15.pdf' = 'invoice content'
+       'scan0042.pdf' = 'pdf content'
+       'Document.docx' = 'doc content'
+       'Tax Return 2024-25.xlsx' = 'tax doc'
+   } | ForEach-Object {
+       $path = Join-Path $testDir $_.Keys; 
+       Set-Content -LiteralPath $path -Value $_.Values
+   }
+   
+   # Run dry-run
+   .\scripts\Rename-MyFiles.ps1 -FolderPath $testDir -WhatIf
+   
+   # Expect: Invoice skipped as "already descriptive", others proposed
+   ```
+
+2. **Test `-Force` flag:**
+   ```powershell
+   .\scripts\Rename-MyFiles.ps1 -FolderPath $testDir -Force -WhatIf
+   
+   # Expect: Even "Invoice" file now shows "PROPOSED" (not skipped)
+   ```
+
+3. **Test unchanged filename detection:**
+   Run against a file where Azure AI would propose the same name as current. Script should skip it as "Filename unchanged".
+
+4. **Check summary output:**
+   ```powershell
+   .\scripts\Rename-MyFiles.ps1 -FolderPath $testDir -WhatIf
+   
+   # Expect summary shows:
+   # Files scanned: (total)
+   # Files renamed: (would rename count)
+   # Files skipped: (total skipped)
+   # Skip breakdown:
+   #   - Already descriptive: (count)  
+   #   - Filename unchanged: (count)
+   ```
+
 ### Phase 6b - Office Document Text Extraction
 
 **Priority:** Medium (frequently renamed, multiple formats)

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -4,13 +4,15 @@ This plan breaks work into small, testable tasks. Update it when the code change
 
 ## Current State Snapshot
 
-**MVP Status:** ✅ **Complete** — All phases 0–5 are finished. Core features are functional and documented.
+**MVP Status:** ✅ **Complete** — All phases 0–5 are finished. Core features are functional and documented. Phase 6 in progress: PDF extraction and intelligent skip logic complete; image and office document extraction pending.
 
 ### What Works Now
 
 - Scripts run locally with PowerShell 7; cross-platform ready (Windows, macOS, Linux).
 - `Rename-MyFiles.ps1`
   - Reads plain-text files (`.txt`, `.md`, `.csv`, `.log`, `.json`, `.xml`, `.html`, `.yaml`, etc.)
+  - Extracts text from PDF files using PdfPig (requires optional `Install-Dependencies.ps1`).
+  - Smart skip: Files with descriptive names (date + business keyword) are skipped to save cost.
   - Uses Azure OpenAI REST API directly for filename proposals.
   - Implements dry-run via `ShouldProcess` with `-WhatIf` support.
   - Handles per-file errors without stopping the batch.
@@ -18,7 +20,8 @@ This plan breaks work into small, testable tasks. Update it when the code change
   - Truncates filenames to Windows limits (255 chars).
   - Makes Windows reserved names safe (e.g., `CON` → `CON_file`).
   - Limits content sent to Azure AI to 8000 characters.
-  - Prints summary of renamed/skipped/failed counts.
+  - Prints summary of renamed/skipped/failed counts with skip breakdowns.
+  - `-Force` flag allows overriding smart skip logic for descriptive filenames.
 - `Deploy-RenameMyFiles.ps1`
   - Uses Azure CLI (`az`) with built-in Bicep support (no separate installation).
   - Creates resource group, Azure OpenAI resource, and GPT-4o mini deployment.
@@ -27,17 +30,18 @@ This plan breaks work into small, testable tasks. Update it when the code change
   - Uses Azure CLI (`az`) for safe resource group deletion.
   - Prompts for confirmation; supports `–Force` flag.
 - All documentation (README, user guide, runbook) updated to reflect current behaviour and limitations.
-- Architecture decisions documented in `DECISIONS/` (ADR-0002, ADR-0003, ADR-0004).
+- Architecture decisions documented in `DECISIONS/` (ADR-0001 through ADR-0005).
 
-### Known Limitations (MVP)
+### Known Limitations (Current Implementation)
 
-- **Plain-text files:** Fully supported (text extraction works).
-- **PDF files:** Use filename context only (no text extraction yet). See Phase 6.
-- **Office documents (`.doc`, `.docx`, `.xls`, `.xlsx`, `.ppt`, `.pptx`):** Use filename context only (no text extraction yet). See Phase 6.
-- **Image formats (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.webp`):** Skipped automatically (no OCR/vision support in MVP).
-- **Other unsupported file types (binary, archives, executables, media):** Skipped automatically.
-- **Subfolder recursion:** Not supported; only top-level files processed.
+- **Plain-text files (MVP):** Fully supported (text extraction works).
+- **PDF files (Phase 6a):** ✅ Text content is extracted using PdfPig (optional dependency). Requires `Install-Dependencies.ps1`. Scanned/encrypted PDFs are skipped.
+- **Image files (JPEG, PNG) (Phase 6b):** ⏳ Not yet supported. Being added in Phase 6b based on user priority. Scanned documents and photos are a primary use case.
+- **Office documents (Phase 6c):** Currently use filename context only (no content extraction). Real extraction coming in Phase 6c.
+- **Other file types (GIF, BMP, TIFF, SVG, etc.):** Skipped automatically.
+- **Subfolder recursion:** Not supported; only top-level files processed. Could be added as `-Recurse` flag in future.
 - **AI-generated names are suggestions:** May not always be perfect; always preview with `-WhatIf` first.
+- **Smart skip limitation:** Files with dates but no business keywords are not skipped, even if the name is reasonable. Use `-Force` to skip the smart-skip check.
 
 ## Phase 0 - Cross-Platform Azure Tooling Migration
 
@@ -351,7 +355,60 @@ This plan breaks work into small, testable tasks. Update it when the code change
    #   - Filename unchanged: (count)
    ```
 
-### Phase 6b - Office Document Text Extraction
+### Phase 6b - Image Processing
+
+**Status:** ⏳ **Not Started**
+
+**Priority:** High (most common file type users scan and dump: scanned documents, receipts, photos)
+
+**Objective:** Add support for image files (primarily JPEG, PNG) by using Optical Character Recognition (OCR) or vision-based AI to extract content and propose filenames.
+
+**Rationale:** Users frequently scan documents (invoices, receipts, letters) as images and need them renamed. Images are likely the primary real-world use case after plain-text files. This phase brings image support previously considered out-of-scope into the active pipeline.
+
+#### Task: Research & Select Image Processing Method
+- [ ] Investigate image processing options:
+  - **Azure Computer Vision (Read API):** Cloud service, provides OCR; costs per image; requires additional Azure SDK.
+  - **Tesseract (CLI):** Free, open-source, cross-platform OCR; requires external tool installation and PATH setup.
+  - **IronOCR (.NET library):** Commercial library, cross-platform; licensing restrictions.
+  - **Azure OpenAI Vision:** Multimodal model (GPT-4V); send image pixels directly for filename proposals; may be cost-effective.
+- [ ] Evaluation criteria:
+  - Format coverage (.jpg, .jpeg, .png minimum; .gif, .bmp optional).
+  - Cross-platform support (Windows, macOS, Linux).
+  - Installation ease (NuGet preferred over external utilities).
+  - Licensing (open source or permissive, no commercial restrictions).
+  - Cost per image vs plain-text processing.
+  - Privacy implications (sending image pixels to third parties vs OCR locally).
+- [ ] Document recommendation and rationale in [DECISIONS/ADR-000X-image-processing.md](DECISIONS/) (future ADR).
+  - Compare OCR + existing filename prompt vs direct vision model approach.
+  - Calculate cost implications for typical batch (e.g., 100 scanned documents).
+
+#### Task: Implement Image Processing
+- [ ] Modify `Get-FileTextContent` function in [scripts/Rename-MyFiles.ps1](scripts/Rename-MyFiles.ps1).
+  - [ ] Add support for `.jpg`, `.jpeg`, `.png` image formats.
+  - [ ] Extract text via chosen method (OCR library or vision API).
+  - [ ] Return extracted text up to 8000 characters (existing limit).
+  - [ ] Handle unsupported/corrupted/unreadable images by catching errors and skipping gracefully.
+  - [ ] Return $null only for truly unsupported formats.
+- [ ] Add optional prerequisite documentation (if library requires installation).
+  - [ ] Specify exact NuGet package/utility version and installation steps.
+  - [ ] Document installation for Windows, macOS, and Linux.
+- [ ] Test with realistic image samples:
+  - [ ] Scanned PDF-as-image (JPEG of invoice).
+  - [ ] Photo of receipt or letter.
+  - [ ] Handwritten image (test OCR limits).
+  - [ ] Corrupted/unreadable image.
+  - [ ] Verify error handling does not stop batch processing.
+- [ ] Update user-guide.md to document image support with caveats.
+  - [ ] Note limitations (handwriting, very low resolution, non-text content like diagrams).
+  - [ ] Clarify cost implications if using vision API.
+
+#### Acceptance Criteria
+- [ ] Script runs without errors when processing mixed batches (text + PDF + images).
+- [ ] Images with readable text are processed; unreadable images are skipped with reason.
+- [ ] Summary report includes image processing results.
+- [ ] Documentation updated for end users.
+
+### Phase 6c - Office Document Text Extraction
 
 **Priority:** Medium (frequently renamed, multiple formats)
 
@@ -389,7 +446,11 @@ This plan breaks work into small, testable tasks. Update it when the code change
   - Note format support (.docx, .xlsx, .pptx, etc.).
   - Note limitations (password-protected, corrupted, etc.).
 
-### Phase 6c - Validation & Release
+### Phase 7 - Validation & Release
+
+**Status:** ⏳ **Not Started**
+
+**Objective:** Comprehensive final testing and validation before any official release or public announcement.
 
 - [ ] Test cross-platform behaviour:
   - Windows (native .NET on Windows or .NET Core).
@@ -405,62 +466,67 @@ This plan breaks work into small, testable tasks. Update it when the code change
 - [ ] Update [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) to mark Phase 6 complete.
 - [ ] Update [README.md](README.md) **Current Limitations** section to reflect new extraction capabilities.
 
-## Future Enhancements (Out of Scope — Not Planned)
+## Future Enhancements (Out of Scope — Not Immediately Planned)
 
-These features are documented as potential future work but are **not in scope** per [SCOPE.md](SCOPE.md):
+These features are documented as potential future work beyond Phase 7 validation:
 
 - **Recursive subfolder processing** — Current design processes only top-level files to keep behaviour straightforward. Could be added as a flag (e.g., `-Recurse`) in a future version.
 - **Batch capacity optimisation** — Scale to 10,000+ files by increasing Azure OpenAI TPM (tokens per minute) quota. Requires quota adjustments and batching logic.
 - **Alternative AI backends** — Currently Azure OpenAI only. Other providers (OpenAI API, Anthropic Claude, etc.) could be added, but would require new integration code and testing.
 - **GUI or web interface** — Current CLI approach is lightweight and cross-platform. A GUI could improve UX for non-technical users but adds complexity and platform-specific dependencies.
 - **File content modification** — Explicitly out of scope. This tool **only renames**; it never edits file contents.
+- **Advanced image understanding** — Handwriting recognition, diagram understanding, multi-modal vision at scale (beyond basic OCR).
 
 ## Assumptions & Design Decisions
 
-### Current Implementation (MVP, Phases 0–5)
+### Current Implementation (MVP Phases 0–5, Phase 6 In Progress)
 
 - **No automated tests:** Validation is manual (dry-run testing, visual inspection). Test harness to be added in future if needed.
-- **Azure OpenAI only:** Single AI backend simplifies code and deployment. Alternative providers deferred to post-MVP.
+- **Azure OpenAI only:** Single AI backend simplifies code and deployment. Alternative providers deferred to post-Phase 7.
 - **Credential passing:** Users supply credentials via environment variables (`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_KEY`) or script parameters for flexibility.
 - **PowerShell 7.2+:** Required for cross-platform support (`$PSVersionTable.PSVersion`). Tested on Windows; untested on macOS/Linux but theoretically compatible.
 - **Azure CLI (az):** Must be installed; verified at script runtime via `Get-Command az`.
 - **Bicep built-in:** Azure CLI includes Bicep compiler; no separate installation needed.
 - **Soft-delete handling:** Bicep property `restore: true` automatically restores recently soft-deleted Azure OpenAI resources during redeployment.
 - **GlobalStandard deployment:** Data may be processed in any Azure region; stricter alternatives (DataZoneStandard, Regional Standard) available at higher cost (documented in ADR-0003).
-- **Plain-text extraction only:** MVP supports `.txt`, `.md`, `.csv`, `.log`, `.json`, `.xml`, `.html`, `.yaml`, `.yml`. PDF and Office use filename context only (Phase 6).
+- **Plain-text extraction (MVP):** Fully supported. PDF extraction (Phase 6a) and smart-skip logic (Phase 6-Smart-Skip) also complete.
+- **Image support priority:** Now prioritised in Phase 6b based on user research showing scanned documents (PDFs, images) are the primary real-world use case.
 
 ### Phase 6 Assumptions (Post-MVP Enhancement)
 
-- **Cross-platform extraction:** PDF and Office extraction must work on Windows, macOS, and Linux without commercial licenses (rules out COM-based Excel, Word APIs).
-- **Library preference:** Favour .NET libraries (via NuGet) over external CLI utilities for better portability and consistency.
-- **Graceful degradation:** If extraction fails (malformed, encrypted, unsupported format), fall back to filename context rather than skip the file.
-- **8000-character limit:** Maintain existing truncation for remaining phases to control Azure OpenAI token usage and costs.
-- **No new mandatory dependencies:** If Phase 6 introduces dependencies, they should be optional or installable via standard package managers (NuGet, Homebrew, apt) without commercial licensing overhead.
+- **User motivation:** Primary real-world use case is renaming scanned documents (PDFs, images) and generic files. Phase 6 prioritises content extraction (PDF, images, Office) and smart skip logic to address this core need.
+- **Cross-platform extraction:** All extraction methods (PDF, images, Office) must work on Windows, macOS, and Linux without commercial licenses.
+- **Library preference:** Favour .NET libraries (via NuGet) or fully free/open-source tools (OCR utilities) over paid cloud services or external utilities requiring PATH setup.
+- **Graceful degradation:** If extraction fails (malformed, encrypted, unreadable), skip the file gracefully rather than stopping the batch.
+- **8000-character limit:** Maintain existing truncation for all extraction phases to control Azure OpenAI token usage and costs.
+- **Optional dependencies:** Image and Office extraction libraries are optional. Users can install them (e.g., `Install-Dependencies.ps1`) if needed; files are skipped with clear guidance if dependencies are missing.
+- **Image support priority:** Images (Phase 6b) are prioritised before Office documents (Phase 6c) because scanned documents are a primary motivation for this tool.
 
-## Phase 7 - Image Support Feasibility (Out of Scope Validation)
+## Phase 8 - Future Considerations: Expanded Features (Out of Scope)
 
 **Status:** ⏳ **Not Started**
 
-**Objective:** Validate whether image files should remain out of scope or move into a future scope update with explicit OCR/vision trade-offs.
+**Objective:** Evaluate longer-term enhancements beyond the current Phase 6 focus.
 
-### Planned Tasks
+### 8a - Deeper Image Understanding (Future Research)
 
-- [ ] Document current behaviour in code and docs as a baseline.
-  - [ ] Confirm `Get-FileTextContent` returns `$null` for image formats in [scripts/Rename-MyFiles.ps1](scripts/Rename-MyFiles.ps1).
-  - [ ] Ensure docs state image formats are skipped in MVP.
-- [ ] Evaluate two implementation paths (research only; no code changes):
-  - [ ] **OCR path:** Extract text from images first, then use existing filename prompt flow.
-  - [ ] **Vision path:** Send image content to a multimodal model for direct filename proposals.
-- [ ] Capture cost and operational implications for both paths.
-  - [ ] Estimate per-image token/processing cost impact vs plain text.
-  - [ ] Note latency impact and likely throughput reduction for large batches.
-  - [ ] Note privacy implications for sending image pixels vs extracted text.
-- [ ] Record decision in a future ADR and update [SCOPE.md](SCOPE.md) only if image support is approved.
+Once basic OCR-based image support is in place (Phase 6b), consider:
 
-### Why This Phase Exists
+- [ ] Advanced OCR for handwriting and complex layouts.
+- [ ] Multi-modal vision models for direct image-to-filename proposals (e.g., GPT-4 Vision at scale).
+- [ ] Diagram and table recognition for technical documents.
 
-- [SCOPE.md](SCOPE.md) currently defines image understanding as out of scope for MVP.
-- This phase prevents accidental scope expansion while still keeping a testable decision trail.
-- Image support is not equivalent to current PDF placeholder behaviour; it requires OCR or multimodal processing.
+### 8b - Recursive Folder Processing
 
-**Assumption:** Until scope changes are explicitly approved, image files remain intentionally unsupported and skipped.
+Currently out of scope. Future enhancement could add:
+
+- [ ] `-Recurse` flag to process subfolders and nested directories.
+- [ ] Preservation of folder hierarchy in renamed files (optional prefixing or flattening).
+
+### 8c - Batch Optimisation
+
+- [ ] Scale to 10,000+ files by optimising Azure OpenAI quota and batching logic.
+- [ ] Parallel processing (with rate-limit awareness) to reduce total runtime.
+- [ ] Resume capability for interrupted batches.
+
+**Note:** These features are intentionally deferred to allow focus on core Phase 6 capabilities (PDF, images, Office documents) and Phase 7 validation.

--- a/plan/RUNBOOK.md
+++ b/plan/RUNBOOK.md
@@ -64,7 +64,11 @@ This repository is organised as follows:
 
 **Problem:** Deployment fails with error `FlagMustBeSetForRestore` — a previously deleted Azure OpenAI resource is soft-deleted and blocking redeployment.
 
-**Default Behaviour:** The Bicep template includes `restore: true`, which automatically restores soft-deleted resources during redeployment. This handles most redeploy scenarios seamlessly.
+**Default Behaviour:** Deployment now runs in two steps automatically:
+1. Tries normal deployment with `restoreOpenAI=false` (works for active resources and normal redeploys).
+2. If Azure returns `FlagMustBeSetForRestore`, retries with `restoreOpenAI=true` to restore the soft-deleted resource.
+
+This avoids `CanNotRestoreAnActiveResource` on active resources while still handling soft-deleted resources without manual intervention.
 
 **Manual Purge (Edge Cases):** If you need to completely purge the soft-deleted resource (e.g., changing location or starting fresh), run:
 

--- a/plan/RUNBOOK.md
+++ b/plan/RUNBOOK.md
@@ -68,7 +68,11 @@ Found 6 file(s). Processing...
 
  Skip breakdown:
    - Already descriptive : 2
-   - Unsupported         : 1
+
+ Skipped files:
+   * Invoice - 2025-02-15.pdf -- Already descriptive
+   * Tax Return 2024.xlsx -- Already descriptive
+   * photo.jpg -- Unsupported or unreadable file type
 -------------------------------------
 ```
 

--- a/plan/RUNBOOK.md
+++ b/plan/RUNBOOK.md
@@ -46,6 +46,42 @@ This repository is organised as follows:
 .\scripts\Rename-MyFiles.ps1 -FolderPath "C:\Documents\MyUnfiledFolder" -WhatIf
 ```
 
+Example dry-run output with smart skip (files with good names are skipped to save cost):
+
+```
+Scanning folder: C:\Documents\MyUnfiledFolder
+Found 6 file(s). Processing...
+
+   SKIPPED  Invoice - 2025-02-15.pdf -- already descriptive
+   PROPOSED scan0042.pdf  ->  Acme Ltd Contract Renewal - 13th January 2026.pdf
+   SKIPPED  Tax Return 2024.xlsx -- already descriptive
+   PROPOSED Document (3).docx  ->  Smith Family Medical Records.docx
+   SKIPPED  photo.jpg -- unsupported or unreadable
+   PROPOSED letter.txt  ->  Dr Brown Appointment Confirmation - 20 February 2026.txt
+
+-------------------------------------
+ Summary
+-------------------------------------
+ Files scanned    : 6
+ Files renamed    : 3
+ Files skipped    : 3
+
+ Skip breakdown:
+   - Already descriptive : 2
+   - Unsupported         : 1
+-------------------------------------
+```
+
+## Run (Force Rename Everything)
+
+To rename all files regardless of their current name quality:
+
+```powershell
+.\scripts\Rename-MyFiles.ps1 -FolderPath "C:\Documents\MyUnfiledFolder" -Force -WhatIf
+```
+
+With `-Force`, the smart skip is disabled and all readable files are processed by Azure AI.
+
 ## Run (Rename)
 
 ```powershell

--- a/scripts/Deploy-RenameMyFiles.ps1
+++ b/scripts/Deploy-RenameMyFiles.ps1
@@ -128,19 +128,57 @@ if ($PSCmdlet.ShouldProcess($ResourceGroupName, 'Deploy Bicep template')) {
 
     $deploymentName = "rename-my-files-$(Get-Date -Format 'yyyyMMddHHmmss')"
 
-    try {
-        $deploymentJson = az deployment group create `
+    function Invoke-RmfDeployment {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [bool]$RestoreOpenAI
+        )
+
+        $restoreValue = if ($RestoreOpenAI) { 'true' } else { 'false' }
+
+        $result = az deployment group create `
             --name $deploymentName `
             --resource-group $ResourceGroupName `
             --template-file $bicepTemplatePath `
-            --parameters location=$Location `
-            --output json
-        
-        if ($LASTEXITCODE -ne 0) {
-            throw "Deployment command failed with exit code $LASTEXITCODE"
+            --parameters location=$Location restoreOpenAI=$restoreValue `
+            --only-show-errors `
+            --output json 2>&1
+
+        return [PSCustomObject]@{
+            ExitCode = $LASTEXITCODE
+            Output   = ($result | Out-String)
         }
-        
-        $deployment = $deploymentJson | ConvertFrom-Json
+    }
+
+    try {
+        # First attempt: normal deployment (active resources should not use restore=true).
+        $deployResult = Invoke-RmfDeployment -RestoreOpenAI $false
+
+        # Retry only when Azure reports a soft-deleted resource that requires restore.
+        if ($deployResult.ExitCode -ne 0 -and $deployResult.Output -match 'FlagMustBeSetForRestore') {
+            Write-Warning 'Soft-deleted Azure OpenAI resource detected. Retrying deployment with restore enabled...'
+            $deployResult = Invoke-RmfDeployment -RestoreOpenAI $true
+        }
+
+        if ($deployResult.ExitCode -ne 0) {
+            throw "Deployment command failed. Azure CLI output: $($deployResult.Output.Trim())"
+        }
+
+        $deploymentJson = $deployResult.Output
+
+        # Azure CLI can occasionally prepend warning text to output; keep only JSON lines.
+        $jsonLines = $deploymentJson -split [Environment]::NewLine | Where-Object {
+            $_ -and $_.Trim() -ne '' -and $_ -notmatch '^\s*WARNING:'
+        }
+        $cleanJson = ($jsonLines -join [Environment]::NewLine).Trim()
+
+        try {
+            $deployment = $cleanJson | ConvertFrom-Json
+        }
+        catch {
+            throw "Failed to parse deployment JSON output. Raw Azure CLI output: $deploymentJson"
+        }
 
         if ($deployment.properties.provisioningState -ne 'Succeeded') {
             throw "Deployment finished with state: $($deployment.properties.provisioningState)"

--- a/scripts/Install-Dependencies.ps1
+++ b/scripts/Install-Dependencies.ps1
@@ -94,7 +94,7 @@ try {
     $sourceDir = Split-Path $dllSource
     
     try {
-        $dlls = @(Get-ChildItem "$sourceDir\*.dll")
+        $dlls = @(Get-ChildItem -Path $sourceDir -Filter '*.dll' -ErrorAction Stop)
     }
     catch {
         throw "Failed to enumerate DLLs in $sourceDir : $_"

--- a/scripts/Install-Dependencies.ps1
+++ b/scripts/Install-Dependencies.ps1
@@ -1,0 +1,153 @@
+<#
+.SYNOPSIS
+    Installs optional dependencies (PdfPig) required for PDF text extraction.
+
+.DESCRIPTION
+    This script downloads the UglyToad.PdfPig NuGet package directly from NuGet.org
+    and extracts the DLL to a local 'lib' folder. No .NET SDK required.
+
+    Requires: PowerShell 7.2+ and internet connection.
+
+.PARAMETER Version
+    Version of PdfPig to install. Defaults to 0.1.13 (latest stable as of March 2026).
+
+.EXAMPLE
+    .\Install-Dependencies.ps1
+
+    Downloads and installs PdfPig v0.1.13 to ./lib/
+
+.EXAMPLE
+    .\Install-Dependencies.ps1 -Version 0.1.12
+
+    Downloads and installs a specific version of PdfPig.
+
+.NOTES
+    Run this script once. After successful installation, Rename-MyFiles.ps1 will
+    automatically use PdfPig for PDF text extraction.
+#>
+
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string]$Version = '0.1.13'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Write-Output "=========================================="
+Write-Output "Installing PDF Support (PdfPig)"
+Write-Output "=========================================="
+Write-Output ""
+
+# Create lib folder if it doesn't exist.
+$libFolder = Join-Path $PSScriptRoot 'lib'
+if (-not (Test-Path -LiteralPath $libFolder)) {
+    New-Item -ItemType Directory -Path $libFolder -Force | Out-Null
+    Write-Output "✓ Created lib folder: $libFolder"
+}
+
+# Download .nupkg from NuGet.org using v2 API (package ID is "PdfPig", not "UglyToad.PdfPig").
+Write-Output "Downloading PdfPig v$Version from NuGet.org..."
+
+$nupkgUrl = "https://www.nuget.org/api/v2/package/PdfPig/$Version"
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "pdfpig-install-$([guid]::NewGuid())"
+$nupkgFile = Join-Path $tempDir "pdfpig.nupkg"
+
+New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+try {
+    # Download .nupkg (which is just a zip file).
+    Invoke-WebRequest -Uri $nupkgUrl -OutFile $nupkgFile -UseBasicParsing
+    Write-Output "✓ Downloaded package"
+    
+    # Extract .nupkg (rename to .zip and expand).
+    $zipFile = Join-Path $tempDir "pdfpig.zip"
+    Copy-Item -LiteralPath $nupkgFile -Destination $zipFile
+    
+    $extractPath = Join-Path $tempDir "extracted"
+    Expand-Archive -Path $zipFile -DestinationPath $extractPath -Force
+    Write-Output "✓ Extracted package"
+    
+    # Find the DLL for the appropriate framework (.NET 6.0 or .NET Standard 2.0).
+    $dllPaths = @(
+        "lib/net6.0/UglyToad.PdfPig.dll",
+        "lib/netstandard2.0/UglyToad.PdfPig.dll",
+        "lib/net5.0/UglyToad.PdfPig.dll"
+    )
+    
+    $dllSource = $null
+    foreach ($relativePath in $dllPaths) {
+        $candidatePath = Join-Path $extractPath $relativePath
+        if (Test-Path -LiteralPath $candidatePath) {
+            $dllSource = $candidatePath
+            Write-Output "✓ Found DLL: $relativePath"
+            break
+        }
+    }
+    
+    if ($null -eq $dllSource) {
+        throw "PdfPig DLL not found in package. Package structure may have changed."
+    }
+    
+    # Copy all DLLs from the source directory to lib folder (including transitive dependencies).
+    $sourceDir = Split-Path $dllSource
+    
+    try {
+        $dlls = @(Get-ChildItem "$sourceDir\*.dll")
+    }
+    catch {
+        throw "Failed to enumerate DLLs in $sourceDir : $_"
+    }
+    
+    if ($dlls.Count -eq 0) {
+        throw "No DLLs found in $sourceDir"
+    }
+    
+    foreach ($dll in $dlls) {
+        $destination = Join-Path $libFolder $dll.Name
+        try {
+            Copy-Item -LiteralPath $dll.FullName -Destination $destination -Force -ErrorAction Stop
+            Write-Output "  ✓ Installed: $($dll.Name)"
+        }
+        catch {
+            if ($_.Exception.Message -match "because it is being used by another process") {
+                Write-Output "  → Skipped: $($dll.Name) (already in use - will use existing version)"
+            }
+            else {
+                throw
+            }
+        }
+    }
+    
+    Write-Output "✓ Installed $($dlls.Count) DLL(s) total"
+    
+    Write-Output ""
+    Write-Output "=========================================="
+    Write-Output "✓ Installation Complete"
+    Write-Output "=========================================="
+    Write-Output ""
+    Write-Output "PDF text extraction is now enabled."
+    Write-Output ""
+    Write-Output "Next steps:"
+    Write-Output "  1. Run Rename-MyFiles.ps1 with PDF files"
+    Write-Output "  2. Add -Verbose to confirm PdfPig loaded:"
+    Write-Output "     .\Rename-MyFiles.ps1 -FolderPath C:\Docs -Verbose"
+    Write-Output ""
+}
+catch {
+    Write-Error "Installation failed: $_"
+    Write-Output ""
+    Write-Output "Troubleshooting:"
+    Write-Output "  • Check your internet connection"
+    Write-Output "  • Try a different version: .\Install-Dependencies.ps1 -Version 0.1.12"
+    Write-Output "  • Check available versions: https://www.nuget.org/packages/PdfPig/"
+    Write-Output "  • Check NuGet.org status: https://status.nuget.org/"
+    exit 1
+}
+finally {
+    # Clean up temp directory.
+    if (Test-Path -LiteralPath $tempDir) {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/Install-Dependencies.ps1
+++ b/scripts/Install-Dependencies.ps1
@@ -44,7 +44,7 @@ Write-Output ""
 $libFolder = Join-Path $PSScriptRoot 'lib'
 if (-not (Test-Path -LiteralPath $libFolder)) {
     New-Item -ItemType Directory -Path $libFolder -Force | Out-Null
-    Write-Output "✓ Created lib folder: $libFolder"
+    Write-Output "[OK] Created lib folder: $libFolder"
 }
 
 # Download .nupkg from NuGet.org using v2 API (package ID is "PdfPig", not "UglyToad.PdfPig").
@@ -59,7 +59,7 @@ New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 try {
     # Download .nupkg (which is just a zip file).
     Invoke-WebRequest -Uri $nupkgUrl -OutFile $nupkgFile -UseBasicParsing
-    Write-Output "✓ Downloaded package"
+    Write-Output "[OK] Downloaded package"
     
     # Extract .nupkg (rename to .zip and expand).
     $zipFile = Join-Path $tempDir "pdfpig.zip"
@@ -67,7 +67,7 @@ try {
     
     $extractPath = Join-Path $tempDir "extracted"
     Expand-Archive -Path $zipFile -DestinationPath $extractPath -Force
-    Write-Output "✓ Extracted package"
+    Write-Output "[OK] Extracted package"
     
     # Find the DLL for the appropriate framework (.NET 6.0 or .NET Standard 2.0).
     $dllPaths = @(
@@ -81,7 +81,7 @@ try {
         $candidatePath = Join-Path $extractPath $relativePath
         if (Test-Path -LiteralPath $candidatePath) {
             $dllSource = $candidatePath
-            Write-Output "✓ Found DLL: $relativePath"
+            Write-Output "[OK] Found DLL: $relativePath"
             break
         }
     }
@@ -108,11 +108,11 @@ try {
         $destination = Join-Path $libFolder $dll.Name
         try {
             Copy-Item -LiteralPath $dll.FullName -Destination $destination -Force -ErrorAction Stop
-            Write-Output "  ✓ Installed: $($dll.Name)"
+            Write-Output "  [OK] Installed: $($dll.Name)"
         }
         catch {
             if ($_.Exception.Message -match "because it is being used by another process") {
-                Write-Output "  → Skipped: $($dll.Name) (already in use - will use existing version)"
+                Write-Output "  [SKIP] $($dll.Name) (already in use - will use existing version)"
             }
             else {
                 throw
@@ -120,11 +120,11 @@ try {
         }
     }
     
-    Write-Output "✓ Installed $($dlls.Count) DLL(s) total"
+    Write-Output "[OK] Installed $($dlls.Count) DLL(s) total"
     
     Write-Output ""
     Write-Output "=========================================="
-    Write-Output "✓ Installation Complete"
+    Write-Output "[OK] Installation Complete"
     Write-Output "=========================================="
     Write-Output ""
     Write-Output "PDF text extraction is now enabled."
@@ -139,10 +139,10 @@ catch {
     Write-Error "Installation failed: $_"
     Write-Output ""
     Write-Output "Troubleshooting:"
-    Write-Output "  • Check your internet connection"
-    Write-Output "  • Try a different version: .\Install-Dependencies.ps1 -Version 0.1.12"
-    Write-Output "  • Check available versions: https://www.nuget.org/packages/PdfPig/"
-    Write-Output "  • Check NuGet.org status: https://status.nuget.org/"
+    Write-Output "  - Check your internet connection"
+    Write-Output "  - Try a different version: .\Install-Dependencies.ps1 -Version 0.1.12"
+    Write-Output "  - Check available versions: https://www.nuget.org/packages/PdfPig/"
+    Write-Output "  - Check NuGet.org status: https://status.nuget.org/"
     exit 1
 }
 finally {

--- a/scripts/Rename-MyFiles.ps1
+++ b/scripts/Rename-MyFiles.ps1
@@ -100,11 +100,18 @@ $ErrorActionPreference = 'Stop'
 $pdfPigLoaded = $false
 $pdfPigAssemblyPath = $null
 
-# Try to find PdfPig in common NuGet locations.
-$nugetPaths = @(
-    "$env:USERPROFILE\.nuget\packages\uglytoad.pdfpig\*\lib\net*\UglyToad.PdfPig.dll",
-    "$PSScriptRoot\..\lib\UglyToad.PdfPig.dll",
-    "$PSScriptRoot\lib\UglyToad.PdfPig.dll"
+# Resolve user profile directory in a cross-platform way for NuGet lookup.
+$userProfile = [Environment]::GetFolderPath('UserProfile')
+if (-not $userProfile) { $userProfile = $HOME }
+
+# Try to find PdfPig in common NuGet and local locations.
+$nugetPaths = @()
+if ($userProfile) {
+    $nugetPaths += Join-Path $userProfile '.nuget' 'packages' 'uglytoad.pdfpig' '*' 'lib' 'net*' 'UglyToad.PdfPig.dll'
+}
+$nugetPaths += @(
+    (Join-Path $PSScriptRoot '..' 'lib' 'UglyToad.PdfPig.dll'),
+    (Join-Path $PSScriptRoot 'lib' 'UglyToad.PdfPig.dll')
 )
 
 foreach ($searchPath in $nugetPaths) {
@@ -151,42 +158,51 @@ function Get-PdfTextContent {
         return $null
     }
 
+    $document = $null
     try {
-        $document = [UglyToad.PdfPig.PdfDocument]::Open($FilePath)
-        
-        if ($null -eq $document) {
-            Write-Verbose "PdfPig returned null document for $FilePath"
-            return $null
-        }
+        try {
+            $document = [UglyToad.PdfPig.PdfDocument]::Open($FilePath)
 
-        $textBuilder = [System.Text.StringBuilder]::new()
-        foreach ($page in $document.GetPages()) {
-            if ($null -ne $page.Text) {
-                $textBuilder.Append($page.Text) | Out-Null
+            if ($null -eq $document) {
+                Write-Verbose "PdfPig returned null document for $FilePath"
+                return $null
+            }
+
+            $textBuilder = [System.Text.StringBuilder]::new()
+            foreach ($page in $document.GetPages()) {
+                if ($null -ne $page.Text) {
+                    $textBuilder.Append($page.Text) | Out-Null
+                    if ($textBuilder.Length -ge 8000) {
+                        break
+                    }
+                }
+            }
+
+            $extractedText = $textBuilder.ToString()
+            if ([string]::IsNullOrWhiteSpace($extractedText)) {
+                Write-Verbose "No text extracted from PDF: $FilePath"
+                return $null
+            }
+
+            # Truncate to 8000 characters to match existing limit.
+            if ($extractedText.Length -gt 8000) {
+                $extractedText = $extractedText.Substring(0, 8000)
+            }
+
+            Write-Verbose "Extracted $($extractedText.Length) characters from PDF: $FilePath"
+            return $extractedText
+        }
+        finally {
+            if ($null -ne $document) {
+                $document.Dispose()
             }
         }
-
-        $document.Dispose()
-
-        $extractedText = $textBuilder.ToString()
-        if ([string]::IsNullOrWhiteSpace($extractedText)) {
-            Write-Verbose "No text extracted from PDF: $FilePath"
-            return $null
-        }
-
-        # Truncate to 8000 characters to match existing limit.
-        if ($extractedText.Length -gt 8000) {
-            $extractedText = $extractedText.Substring(0, 8000)
-        }
-
-        Write-Verbose "Extracted $($extractedText.Length) characters from PDF: $FilePath"
-        return $extractedText
     }
     catch {
         # Distinguish between dependency/installation errors vs. PDF content errors.
         if ($_.Exception.Message -match "Could not load file or assembly") {
-            Write-Error "Missing PdfPig dependency for $FilePath : Run '.\scripts\Install-Dependencies.ps1' to install all required libraries. Error: $_"
-            throw  # Stop script execution on dependency errors.
+            Write-Warning "Missing PdfPig dependency for $FilePath : Run '.\scripts\Install-Dependencies.ps1' to install all required libraries. Error: $_"
+            return $null
         }
         else {
             # PDF content error (scanned, encrypted, corrupted, etc).
@@ -198,8 +214,9 @@ function Get-PdfTextContent {
 
 # ---------------------------------------------------------------------------
 # Helper: Read file content as plain text, with PDF support.
-# Returns a string (content or placeholder), never $null.
-# Returns $null only if the file type is unsupported.
+# Returns the file content as text when successful.
+# May return $null if the file type is unsupported or the file cannot be read
+# (including PDF extraction failures or missing PdfPig).
 # ---------------------------------------------------------------------------
 function Get-FileTextContent {
     [CmdletBinding()]
@@ -284,10 +301,7 @@ function Invoke-AzureOpenAIFilenameProposal {
         [int]$MaxPromptCharacters = 1200,
 
         [Parameter()]
-        [int]$MaxRetries = 3,
-
-        [Parameter()]
-        [int]$InitialDelaySeconds = 2
+        [int]$MaxRetries = 3
     )
 
     $systemPrompt = @'
@@ -390,7 +404,7 @@ Examples of good output:
                     $jitter = (Get-Random -Minimum -0.25 -Maximum 0.25) * $retryAfterSeconds
                     $actualDelay = [Math]::Max(1, [Math]::Ceiling($retryAfterSeconds + $jitter))
 
-                    Write-Verbose "Rate limit hit for '$OriginalFileName'. Waiting ${actualDelay}s before retry (attempt $($retryCount + 1)/$MaxRetries)..."
+                    Write-Verbose "Rate limit hit for '$OriginalFileName'. Waiting ${actualDelay}s before retry $($retryCount + 1) of $MaxRetries..."
                     Start-Sleep -Seconds $actualDelay
                     $retryCount++
                     continue

--- a/scripts/Rename-MyFiles.ps1
+++ b/scripts/Rename-MyFiles.ps1
@@ -35,7 +35,7 @@
 
 .PARAMETER Force
     Force rename even if the current filename already appears descriptive.
-    By default, files with good names (containing dates and business keywords) are skipped to save cost.
+    By default, Azure AI may keep the existing filename unchanged when it is already clear and useful.
 
 .PARAMETER WhatIf
     Shows what files would be renamed without actually renaming them.
@@ -133,7 +133,7 @@ foreach ($searchPath in $nugetPaths) {
 
 if (-not $pdfPigLoaded) {
     Write-Warning @"
-⚠️  PdfPig library not found. PDF files will be SKIPPED.
+WARNING: PdfPig library not found. PDF files will be SKIPPED.
 
 To enable PDF support, run the installation script:
     .\scripts\Install-Dependencies.ps1
@@ -297,6 +297,9 @@ function Invoke-AzureOpenAIFilenameProposal {
         [string]$DeploymentName,
 
         [Parameter()]
+        [switch]$AlwaysSuggestNewName,
+
+        [Parameter()]
         [ValidateRange(400, 8000)]
         [int]$MaxPromptCharacters = 1200,
 
@@ -304,7 +307,14 @@ function Invoke-AzureOpenAIFilenameProposal {
         [int]$MaxRetries = 3
     )
 
-    $systemPrompt = @'
+    $filenamePolicy = if ($AlwaysSuggestNewName) {
+        '- Even if the current filename is already good, suggest a better descriptive filename.'
+    }
+    else {
+        '- If the current filename is already clear, specific, and useful, return it unchanged (without extension).'
+    }
+
+    $systemPrompt = @"
 You are a file-naming assistant. Your only job is to propose a clear, descriptive, human-readable
 filename for a document based on its content.
 
@@ -316,6 +326,7 @@ Rules:
 - Keep the name concise but descriptive (aim for under 80 characters).
 - Avoid special characters that are invalid on Windows filesystems: \ / : * ? " < > |
 - If you cannot reliably determine specific details, still propose the best descriptive name you can.
+$filenamePolicy
 - Respond with ONLY the proposed filename -- no explanation, no punctuation at the end.
 
 Examples of good output:
@@ -323,7 +334,7 @@ Examples of good output:
   HMRC Self Assessment Tax Return 2024-25
   Dr Smith Referral Letter - Patient John Doe
   Electricity Bill - March 2025
-'@
+"@
 
     $userPrompt = "Original filename: $OriginalFileName`n`nDocument content:`n$FileContent"
 
@@ -400,7 +411,7 @@ Examples of good output:
                         Write-Verbose "Using server-provided Retry-After: ${retryAfterSeconds}s"
                     }
 
-                    # Add jitter (±25% random variation to avoid thundering herd).
+                    # Add jitter (+/-25% random variation to avoid thundering herd).
                     $jitter = (Get-Random -Minimum -0.25 -Maximum 0.25) * $retryAfterSeconds
                     $actualDelay = [Math]::Max(1, [Math]::Ceiling($retryAfterSeconds + $jitter))
 
@@ -511,57 +522,6 @@ function Resolve-UniqueFilePath {
 }
 
 # ---------------------------------------------------------------------------
-# Helper: Detect if a filename appears to already be descriptive.
-# Returns $true if filename contains date patterns AND business keywords,
-# suggesting it's already a good name and doesn't need renaming.
-# ---------------------------------------------------------------------------
-function Test-FilenameIsDescriptive {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [string]$FileName
-    )
-
-    # Remove extension for analysis.
-    $nameWithoutExt = [System.IO.Path]::GetFileNameWithoutExtension($FileName)
-
-    # Business keywords indicating a file likely has good structure.
-    $businessKeywords = @(
-        'invoice', 'receipt', 'statement', 'letter', 'report', 'agreement',
-        'contract', 'proposal', 'quote', 'order', 'payment', 'tax', 'return',
-        'refund', 'certification', 'license', 'policy', 'procedure', 'manual',
-        'specification', 'estimate', 'schedule', 'summary', 'analysis', 'plan',
-        'budget', 'forecast', 'audit', 'assessment', 'checklist', 'form',
-        'application', 'renewal', 'confirmation', 'notification', 'appointment',
-        'fee', 'charge', 'bill'
-    )
-
-    # Check for date patterns (case-insensitive).
-    $hasDate = ($nameWithoutExt -match '\d{4}-\d{2}-\d{2}') -or  # YYYY-MM-DD
-               ($nameWithoutExt -match '\d{1,2}/\d{1,2}/\d{2,4}') -or  # MM/DD/YYYY or DD/MM/YYYY
-               ($nameWithoutExt -match '(?i)(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}') -or  # Month YYYY
-               ($nameWithoutExt -match '(?i)(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{4}') -or  # Mon YYYY
-               ($nameWithoutExt -match '\b(20|19)\d{2}\b')  # 4-digit year
-
-    if (-not $hasDate) {
-        Write-Verbose "Test-FilenameIsDescriptive: '$FileName' has no date pattern. Not descriptive."
-        return $false  # No date = likely not descriptive enough.
-    }
-
-    # Check for business keywords (case-insensitive).
-    foreach ($keyword in $businessKeywords) {
-        if ($nameWithoutExt -match "(?i)\b$keyword\b") {
-            Write-Verbose "Test-FilenameIsDescriptive: '$FileName' has date + keyword '$keyword'. Descriptive."
-            return $true  # One keyword + date is a good sign.
-        }
-    }
-
-    # Date present but no keywords; consider format-only names like "scan0042" or "Document (3)" as NOT descriptive.
-    Write-Verbose "Test-FilenameIsDescriptive: '$FileName' has date but no business keywords. Not descriptive."
-    return $false
-}
-
-# ---------------------------------------------------------------------------
 # Main processing
 # ---------------------------------------------------------------------------
 
@@ -588,20 +548,10 @@ Write-Output "Found $($files.Count) file(s). Processing..."
 $countRenamed  = 0
 $countSkipped  = 0
 $countUnchanged = 0
-$countDescriptive = 0
 $skippedFiles  = [System.Collections.Generic.List[PSCustomObject]]::new()
 
 foreach ($file in $files) {
     Write-Verbose "Processing: $($file.Name)"
-
-    # Step 0: Check if current filename is already descriptive (and user didn't force).
-    if (-not $Force -and (Test-FilenameIsDescriptive -FileName $file.Name)) {
-        Write-Output "  SKIPPED  $($file.Name) -- already descriptive"
-        $skippedFiles.Add([PSCustomObject]@{ Name = $file.Name; Reason = 'Already descriptive' })
-        $countSkipped++
-        $countDescriptive++
-        continue
-    }
 
     # Step 1: Read content.
     $content = Get-FileTextContent -File $file
@@ -619,6 +569,7 @@ foreach ($file in $files) {
         -Endpoint $AzureOpenAIEndpoint `
         -ApiKey $AzureOpenAIKey `
         -DeploymentName $DeploymentName `
+        -AlwaysSuggestNewName:$Force `
         -MaxPromptCharacters $MaxPromptCharacters
 
     if ($null -eq $proposed) {
@@ -691,15 +642,10 @@ Write-Output " Files scanned    : $($files.Count)"
 Write-Output " Files renamed    : $countRenamed"
 Write-Output " Files skipped    : $countSkipped"
 
-if ($countDescriptive -gt 0 -or $countUnchanged -gt 0) {
+if ($countUnchanged -gt 0) {
     Write-Output ''
     Write-Output ' Skip breakdown:'
-    if ($countDescriptive -gt 0) {
-        Write-Output "   - Already descriptive : $countDescriptive"
-    }
-    if ($countUnchanged -gt 0) {
-        Write-Output "   - Filename unchanged   : $countUnchanged"
-    }
+    Write-Output "   - Filename unchanged   : $countUnchanged"
 }
 
 if ($skippedFiles.Count -gt 0) {

--- a/scripts/Rename-MyFiles.ps1
+++ b/scripts/Rename-MyFiles.ps1
@@ -25,6 +25,14 @@
 .PARAMETER DeploymentName
     The name of the Azure OpenAI model deployment to use. Defaults to 'gpt-4o-mini'.
 
+.PARAMETER RequestThrottleSeconds
+    Delay in seconds between Azure OpenAI API calls to avoid rate limits (default: 5 seconds).
+    Default is tuned for typical usage with moderate quota. Most users should not need to change this.
+
+.PARAMETER MaxPromptCharacters
+    Maximum characters sent to Azure OpenAI from each file (default: 900).
+    Lower values reduce token usage and cost per file. Default is set for low-cost operation.
+
 .PARAMETER WhatIf
     Shows what files would be renamed without actually renaming them.
 
@@ -42,6 +50,8 @@
     .\Rename-MyFiles.ps1 -FolderPath "C:\Documents\Unfiled" -Verbose
 
     Renames files with detailed progress output.
+
+
 
 .NOTES
     Requires PowerShell 7.2 or later.
@@ -63,15 +73,126 @@ param (
 
     [Parameter(HelpMessage = 'Azure OpenAI model deployment name.')]
     [ValidateNotNullOrEmpty()]
-    [string]$DeploymentName = 'gpt-4o-mini'
+    [string]$DeploymentName = 'gpt-4o-mini',
+
+    [Parameter(HelpMessage = 'Delay in seconds between Azure OpenAI API calls to avoid TPM/RPM rate limits.')]
+    [ValidateRange(0, 60)]
+    [int]$RequestThrottleSeconds = 5,
+
+    [Parameter(HelpMessage = 'Maximum number of characters sent to Azure OpenAI from each file (lower values reduce token usage).')]
+    [ValidateRange(400, 8000)]
+    [int]$MaxPromptCharacters = 900
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 # ---------------------------------------------------------------------------
-# Helper: Read file content as plain text, with basic support for PDF.
-# Returns $null if the file type is unsupported or unreadable.
+# Module loading: Attempt to load PdfPig for PDF text extraction.
+# ---------------------------------------------------------------------------
+$pdfPigLoaded = $false
+$pdfPigAssemblyPath = $null
+
+# Try to find PdfPig in common NuGet locations.
+$nugetPaths = @(
+    "$env:USERPROFILE\.nuget\packages\uglytoad.pdfpig\*\lib\net*\UglyToad.PdfPig.dll",
+    "$PSScriptRoot\..\lib\UglyToad.PdfPig.dll",
+    "$PSScriptRoot\lib\UglyToad.PdfPig.dll"
+)
+
+foreach ($searchPath in $nugetPaths) {
+    $resolvedPath = Resolve-Path -Path $searchPath -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($resolvedPath) {
+        $pdfPigAssemblyPath = $resolvedPath.Path
+        try {
+            Add-Type -LiteralPath $pdfPigAssemblyPath -ErrorAction Stop
+            $pdfPigLoaded = $true
+            Write-Verbose "Successfully loaded PdfPig from: $pdfPigAssemblyPath"
+            break
+        }
+        catch {
+            Write-Verbose "Failed to load PdfPig from $pdfPigAssemblyPath : $_"
+            $pdfPigLoaded = $false
+        }
+    }
+}
+
+if (-not $pdfPigLoaded) {
+    Write-Warning @"
+⚠️  PdfPig library not found. PDF files will be SKIPPED.
+
+To enable PDF support, run the installation script:
+    .\scripts\Install-Dependencies.ps1
+
+Then run this script again. For details, see: docs/user-guide.md > Enabling PDF text extraction
+"@
+}
+
+# ---------------------------------------------------------------------------
+# Helper: Extract text from a PDF file using PdfPig.
+# Returns extracted text up to 8000 characters, or $null on failure.
+# ---------------------------------------------------------------------------
+function Get-PdfTextContent {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$FilePath
+    )
+
+    if (-not $pdfPigLoaded) {
+        Write-Verbose "PdfPig not loaded. Cannot extract PDF text from $FilePath"
+        return $null
+    }
+
+    try {
+        $document = [UglyToad.PdfPig.PdfDocument]::Open($FilePath)
+        
+        if ($null -eq $document) {
+            Write-Verbose "PdfPig returned null document for $FilePath"
+            return $null
+        }
+
+        $textBuilder = [System.Text.StringBuilder]::new()
+        foreach ($page in $document.GetPages()) {
+            if ($null -ne $page.Text) {
+                $textBuilder.Append($page.Text) | Out-Null
+            }
+        }
+
+        $document.Dispose()
+
+        $extractedText = $textBuilder.ToString()
+        if ([string]::IsNullOrWhiteSpace($extractedText)) {
+            Write-Verbose "No text extracted from PDF: $FilePath"
+            return $null
+        }
+
+        # Truncate to 8000 characters to match existing limit.
+        if ($extractedText.Length -gt 8000) {
+            $extractedText = $extractedText.Substring(0, 8000)
+        }
+
+        Write-Verbose "Extracted $($extractedText.Length) characters from PDF: $FilePath"
+        return $extractedText
+    }
+    catch {
+        # Distinguish between dependency/installation errors vs. PDF content errors.
+        if ($_.Exception.Message -match "Could not load file or assembly") {
+            Write-Error "Missing PdfPig dependency for $FilePath : Run '.\scripts\Install-Dependencies.ps1' to install all required libraries. Error: $_"
+            throw  # Stop script execution on dependency errors.
+        }
+        else {
+            # PDF content error (scanned, encrypted, corrupted, etc).
+            Write-Verbose "PDF extraction error for $FilePath : $_"
+            return $null
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Helper: Read file content as plain text, with PDF support.
+# Returns a string (content or placeholder), never $null.
+# Returns $null only if the file type is unsupported.
 # ---------------------------------------------------------------------------
 function Get-FileTextContent {
     [CmdletBinding()]
@@ -90,13 +211,22 @@ function Get-FileTextContent {
             }
 
             '.pdf' {
-                # TODO: For production use, consider adding iTextSharp or PdfPig via NuGet,
-                # or using a pre-installed pdftotext utility. This stub returns a placeholder.
-                # Example with pdftotext (if installed):
-                #   $text = & pdftotext $File.FullName -
-                #   return $text
-                Write-Verbose "PDF extraction is not fully implemented. Using filename as context for: $($File.Name)"
-                return "[PDF file: $($File.Name)]"
+                # Require PdfPig for PDF extraction -- do not degrade to filename context.
+                if (-not $pdfPigLoaded) {
+                    Write-Verbose "PdfPig not loaded. Skipping PDF file: $($File.Name)"
+                    return $null
+                }
+                
+                $extractedText = Get-PdfTextContent -FilePath $File.FullName
+                if ($null -ne $extractedText) {
+                    # Extraction succeeded.
+                    return $extractedText
+                }
+                else {
+                    # Extraction failed (corrupted, scanned, encrypted, etc).
+                    Write-Verbose "Could not extract text from PDF: $($File.Name) (may be scanned, encrypted, or corrupted)"
+                    return $null
+                }
             }
 
             { $_ -in '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx' } {
@@ -121,6 +251,7 @@ function Get-FileTextContent {
 
 # ---------------------------------------------------------------------------
 # Helper: Call Azure OpenAI to propose a filename for the given content.
+# Includes exponential backoff retry for rate limit errors.
 # Returns a proposed filename string (without extension), or $null on failure.
 # ---------------------------------------------------------------------------
 function Invoke-AzureOpenAIFilenameProposal {
@@ -139,7 +270,17 @@ function Invoke-AzureOpenAIFilenameProposal {
         [string]$ApiKey,
 
         [Parameter(Mandatory)]
-        [string]$DeploymentName
+        [string]$DeploymentName,
+
+        [Parameter()]
+        [ValidateRange(400, 8000)]
+        [int]$MaxPromptCharacters = 1200,
+
+        [Parameter()]
+        [int]$MaxRetries = 3,
+
+        [Parameter()]
+        [int]$InitialDelaySeconds = 2
     )
 
     $systemPrompt = @'
@@ -165,9 +306,10 @@ Examples of good output:
 
     $userPrompt = "Original filename: $OriginalFileName`n`nDocument content:`n$FileContent"
 
-    # Truncate content to avoid exceeding token limits (approx 6000 chars ~ 1500 tokens).
-    if ($userPrompt.Length -gt 8000) {
-        $userPrompt = $userPrompt.Substring(0, 8000) + "`n[... content truncated ...]"
+    # Truncate content to avoid exceeding token limits.
+    # Low-cost default: 900 chars to keep per-file token usage and rate-limit risk lower.
+    if ($userPrompt.Length -gt $MaxPromptCharacters) {
+        $userPrompt = $userPrompt.Substring(0, $MaxPromptCharacters) + "`n[... content truncated ...]"
     }
 
     $requestBody = @{
@@ -181,17 +323,89 @@ Examples of good output:
 
     $uri = "$($Endpoint.TrimEnd('/'))/openai/deployments/$DeploymentName/chat/completions?api-version=2024-02-01"
 
-    try {
-        $response = Invoke-RestMethod -Uri $uri -Method Post -ContentType 'application/json' -Body $requestBody -Headers @{
-            'api-key' = $ApiKey
+    $retryCount = 0
+
+    while ($retryCount -le $MaxRetries) {
+        try {
+            $response = Invoke-RestMethod -Uri $uri -Method Post -ContentType 'application/json' -Body $requestBody -Headers @{
+                'api-key' = $ApiKey
+            }
+            $proposed = $response.choices[0].message.content.Trim()
+            return $proposed
         }
-        $proposed = $response.choices[0].message.content.Trim()
-        return $proposed
+        catch {
+            $errorMessage = $_.Exception.Message
+            $statusCode = $_.Exception.Response.StatusCode.value__ 2>$null
+
+            # Check for rate limit (429 Too Many Requests or RateLimitReached error code).
+            $isRateLimit = ($statusCode -eq 429) -or ($errorMessage -match 'RateLimitReached|rate.limit|quota')
+            
+            if ($isRateLimit) {
+                if ($retryCount -lt $MaxRetries) {
+                    # Extract Retry-After header (Microsoft recommended approach).
+                    $retryAfterSeconds = $null
+                    try {
+                        $httpResponse = $_.Exception.Response
+                        if ($null -ne $httpResponse -and $null -ne $httpResponse.Headers) {
+                            # Try Retry-After header (seconds).
+                            $retryAfterValues = $httpResponse.Headers.GetValues('Retry-After')
+                            if ($null -ne $retryAfterValues -and $retryAfterValues.Count -gt 0) {
+                                $retryAfterSeconds = [int]$retryAfterValues[0]
+                            }
+                            
+                            # Try retry-after-ms header (milliseconds).
+                            if ($null -eq $retryAfterSeconds) {
+                                $retryAfterMsValues = $httpResponse.Headers.GetValues('retry-after-ms')
+                                if ($null -ne $retryAfterMsValues -and $retryAfterMsValues.Count -gt 0) {
+                                    $retryAfterSeconds = [Math]::Ceiling([int]$retryAfterMsValues[0] / 1000)
+                                }
+                            }
+                        }
+                    }
+                    catch {
+                        # Header parsing failed; fall back to exponential backoff.
+                        Write-Verbose "Could not parse Retry-After header: $_"
+                    }
+
+                    # Use server-provided wait time if available, otherwise exponential backoff.
+                    if ($null -eq $retryAfterSeconds -or $retryAfterSeconds -le 0) {
+                        # For rate limits, use longer base delay (10s) since TPM quotas replenish slowly.
+                        # Standard exponential backoff: 10s, 20s, 40s (capped at 60s).
+                        $retryAfterSeconds = 10 * [Math]::Pow(2, $retryCount)
+                        $retryAfterSeconds = [Math]::Min($retryAfterSeconds, 60)  # Cap at 60s
+                        Write-Verbose "No Retry-After header found; using exponential backoff: ${retryAfterSeconds}s"
+                    }
+                    else {
+                        Write-Verbose "Using server-provided Retry-After: ${retryAfterSeconds}s"
+                    }
+
+                    # Add jitter (±25% random variation to avoid thundering herd).
+                    $jitter = (Get-Random -Minimum -0.25 -Maximum 0.25) * $retryAfterSeconds
+                    $actualDelay = [Math]::Max(1, [Math]::Ceiling($retryAfterSeconds + $jitter))
+
+                    Write-Verbose "Rate limit hit for '$OriginalFileName'. Waiting ${actualDelay}s before retry (attempt $($retryCount + 1)/$MaxRetries)..."
+                    Start-Sleep -Seconds $actualDelay
+                    $retryCount++
+                    continue
+                }
+                else {
+                    Write-Warning "Rate limit exceeded for '$OriginalFileName' after $MaxRetries retries."
+                    Write-Warning "The script is already using low-cost defaults."
+                    Write-Warning "If this persists, your Azure OpenAI quota is likely too low for current batch size."
+                    return $null
+                }
+            }
+
+            # Other errors (not rate limit).
+            Write-Verbose "Azure OpenAI call failed for '$OriginalFileName' (attempt $($retryCount + 1)): $errorMessage"
+            
+            # Don't retry non-rate-limit errors.
+            return $null
+        }
     }
-    catch {
-        Write-Verbose "Azure OpenAI call failed for '$OriginalFileName': $_"
-        return $null
-    }
+
+    Write-Warning "Failed to get filename proposal for '$OriginalFileName' after $MaxRetries retries."
+    return $null
 }
 
 # ---------------------------------------------------------------------------
@@ -321,13 +535,20 @@ foreach ($file in $files) {
         -OriginalFileName $file.Name `
         -Endpoint $AzureOpenAIEndpoint `
         -ApiKey $AzureOpenAIKey `
-        -DeploymentName $DeploymentName
+        -DeploymentName $DeploymentName `
+        -MaxPromptCharacters $MaxPromptCharacters
 
     if ($null -eq $proposed) {
         $skippedFiles.Add([PSCustomObject]@{ Name = $file.Name; Reason = 'Azure AI call failed' })
         $countSkipped++
         Write-Output "  SKIPPED  $($file.Name) -- Azure AI call failed"
         continue
+    }
+
+    # Pace requests to avoid bursting into TPM/RPM limits (Microsoft recommended approach).
+    if ($RequestThrottleSeconds -gt 0) {
+        Write-Verbose "Throttling: waiting ${RequestThrottleSeconds}s before next API call..."
+        Start-Sleep -Seconds $RequestThrottleSeconds
     }
 
     # Step 3: Sanitise the proposed name.

--- a/scripts/Rename-MyFiles.ps1
+++ b/scripts/Rename-MyFiles.ps1
@@ -33,6 +33,10 @@
     Maximum characters sent to Azure OpenAI from each file (default: 900).
     Lower values reduce token usage and cost per file. Default is set for low-cost operation.
 
+.PARAMETER Force
+    Force rename even if the current filename already appears descriptive.
+    By default, files with good names (containing dates and business keywords) are skipped to save cost.
+
 .PARAMETER WhatIf
     Shows what files would be renamed without actually renaming them.
 
@@ -81,7 +85,10 @@ param (
 
     [Parameter(HelpMessage = 'Maximum number of characters sent to Azure OpenAI from each file (lower values reduce token usage).')]
     [ValidateRange(400, 8000)]
-    [int]$MaxPromptCharacters = 900
+    [int]$MaxPromptCharacters = 900,
+
+    [Parameter(HelpMessage = 'Force rename even if current filename appears already descriptive.')]
+    [switch]$Force
 )
 
 Set-StrictMode -Version Latest
@@ -490,6 +497,57 @@ function Resolve-UniqueFilePath {
 }
 
 # ---------------------------------------------------------------------------
+# Helper: Detect if a filename appears to already be descriptive.
+# Returns $true if filename contains date patterns AND business keywords,
+# suggesting it's already a good name and doesn't need renaming.
+# ---------------------------------------------------------------------------
+function Test-FilenameIsDescriptive {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$FileName
+    )
+
+    # Remove extension for analysis.
+    $nameWithoutExt = [System.IO.Path]::GetFileNameWithoutExtension($FileName)
+
+    # Business keywords indicating a file likely has good structure.
+    $businessKeywords = @(
+        'invoice', 'receipt', 'statement', 'letter', 'report', 'agreement',
+        'contract', 'proposal', 'quote', 'order', 'payment', 'tax', 'return',
+        'refund', 'certification', 'license', 'policy', 'procedure', 'manual',
+        'specification', 'estimate', 'schedule', 'summary', 'analysis', 'plan',
+        'budget', 'forecast', 'audit', 'assessment', 'checklist', 'form',
+        'application', 'renewal', 'confirmation', 'notification', 'appointment',
+        'fee', 'charge', 'bill'
+    )
+
+    # Check for date patterns (case-insensitive).
+    $hasDate = ($nameWithoutExt -match '\d{4}-\d{2}-\d{2}') -or  # YYYY-MM-DD
+               ($nameWithoutExt -match '\d{1,2}/\d{1,2}/\d{2,4}') -or  # MM/DD/YYYY or DD/MM/YYYY
+               ($nameWithoutExt -match '(?i)(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}') -or  # Month YYYY
+               ($nameWithoutExt -match '(?i)(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{4}') -or  # Mon YYYY
+               ($nameWithoutExt -match '\b(20|19)\d{2}\b')  # 4-digit year
+
+    if (-not $hasDate) {
+        Write-Verbose "Test-FilenameIsDescriptive: '$FileName' has no date pattern. Not descriptive."
+        return $false  # No date = likely not descriptive enough.
+    }
+
+    # Check for business keywords (case-insensitive).
+    foreach ($keyword in $businessKeywords) {
+        if ($nameWithoutExt -match "(?i)\b$keyword\b") {
+            Write-Verbose "Test-FilenameIsDescriptive: '$FileName' has date + keyword '$keyword'. Descriptive."
+            return $true  # One keyword + date is a good sign.
+        }
+    }
+
+    # Date present but no keywords; consider format-only names like "scan0042" or "Document (3)" as NOT descriptive.
+    Write-Verbose "Test-FilenameIsDescriptive: '$FileName' has date but no business keywords. Not descriptive."
+    return $false
+}
+
+# ---------------------------------------------------------------------------
 # Main processing
 # ---------------------------------------------------------------------------
 
@@ -515,10 +573,21 @@ Write-Output "Found $($files.Count) file(s). Processing..."
 
 $countRenamed  = 0
 $countSkipped  = 0
+$countUnchanged = 0
+$countDescriptive = 0
 $skippedFiles  = [System.Collections.Generic.List[PSCustomObject]]::new()
 
 foreach ($file in $files) {
     Write-Verbose "Processing: $($file.Name)"
+
+    # Step 0: Check if current filename is already descriptive (and user didn't force).
+    if (-not $Force -and (Test-FilenameIsDescriptive -FileName $file.Name)) {
+        Write-Output "  SKIPPED  $($file.Name) -- already descriptive"
+        $skippedFiles.Add([PSCustomObject]@{ Name = $file.Name; Reason = 'Already descriptive' })
+        $countSkipped++
+        $countDescriptive++
+        continue
+    }
 
     # Step 1: Read content.
     $content = Get-FileTextContent -File $file
@@ -560,7 +629,16 @@ foreach ($file in $files) {
         continue
     }
 
-    # Step 4: Resolve a unique destination path.
+    # Step 4: Check if proposed filename is identical to current filename.
+    if ([string]::Equals($sanitised, [System.IO.Path]::GetFileNameWithoutExtension($file.Name), [System.StringComparison]::OrdinalIgnoreCase)) {
+        Write-Output "  SKIPPED  $($file.Name) -- filename unchanged"
+        $skippedFiles.Add([PSCustomObject]@{ Name = $file.Name; Reason = 'Filename unchanged' })
+        $countSkipped++
+        $countUnchanged++
+        continue
+    }
+
+    # Step 5: Resolve a unique destination path.
     $destinationPath = Resolve-UniqueFilePath `
         -Directory $file.DirectoryName `
         -BaseName $sanitised `
@@ -568,7 +646,7 @@ foreach ($file in $files) {
 
     $newName = Split-Path $destinationPath -Leaf
 
-    # Step 5: Rename (or preview in -WhatIf mode).
+    # Step 6: Rename (or preview in -WhatIf mode).
     if ($PSCmdlet.ShouldProcess($file.Name, "Rename to '$newName'")) {
         try {
             Rename-Item -LiteralPath $file.FullName -NewName $newName -ErrorAction Stop
@@ -595,9 +673,20 @@ Write-Output ''
 Write-Output '-------------------------------------'
 Write-Output ' Summary'
 Write-Output '-------------------------------------'
-Write-Output " Files scanned : $($files.Count)"
-Write-Output " Files renamed : $countRenamed"
-Write-Output " Files skipped : $countSkipped"
+Write-Output " Files scanned    : $($files.Count)"
+Write-Output " Files renamed    : $countRenamed"
+Write-Output " Files skipped    : $countSkipped"
+
+if ($countDescriptive -gt 0 -or $countUnchanged -gt 0) {
+    Write-Output ''
+    Write-Output ' Skip breakdown:'
+    if ($countDescriptive -gt 0) {
+        Write-Output "   - Already descriptive : $countDescriptive"
+    }
+    if ($countUnchanged -gt 0) {
+        Write-Output "   - Filename unchanged   : $countUnchanged"
+    }
+}
 
 if ($skippedFiles.Count -gt 0) {
     Write-Output ''


### PR DESCRIPTION
Enhance the tool to extract meaningful text from PDF files, allowing filenames to be generated based on document content rather than original filenames. This implementation does not rely on external tools and utilizes PowerShell-compatible methods. The extracted text is limited to 8000 characters, and unreadable or encrypted PDFs are logged and skipped to maintain batch processing integrity. Unit tests validate extraction functionality, and documentation has been updated to reflect this new PDF support.

Fixes #3